### PR TITLE
[Feat] : 모바일 뷰 레이아웃 설정 #6

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,9 @@ export default function RootLayout({
   return (
     <html>
       <body>
-        <RecoilRoot>{children}</RecoilRoot>
+        <div className="m-auto h-full max-w-[calc(100vh*0.6)]">
+          <RecoilRoot>{children}</RecoilRoot>
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
# Describe your changes
- 모바일 뷰 레이아웃을 설정했습니다. 
### 웹뷰에서 모바일 뷰로 보이는 이유
  - `calc(100vh*0.6)`를 max width로 설정했기 때문입니다. (view port height * 0.6)
    대부분의 모바일은 가로:세로 비율이 0.6:1을 넘지 않기 때문에 기본적으로 width가 max-width를 넘지 않고, 그래서 width가 전부 채워진 채로 보이게 됩니다.
   하지만 웹 에서는 가로의 비율이 세로보다 짧기 때문에, max-width가 설정되고 양 옆이 비워진채로 보이게 됩니다. 

- #### 주의) tailwind css 에서 calc를 쓸 때 띄어쓰기를 쓰면 반영이 안됩니다. ㅎㅎㅎㅎ 
  - `max-w-[calc(100vh*0.6)]` 이런식으로 calc함수의 괄호 내부에는 띄어쓰기 없이 작성해주세요.

# Issue number and link
- #6
