### PR TITLE
[Feat] 글작성 페이지 1차 구현

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,18 +1,18 @@
 'use client';
 import useInput from '@/hooks/useInput';
-// import { axiosInstance } from '@/utils/axios';
+import { axiosInstance } from '@/utils/axios';
 
-export default function Add() {
-  const [message, , handleMessage] = useInput('');
+export default function Add(id: { id: string }) {
+  const [text, , handleText] = useInput('');
   const [photo, setPhoto] = useInput(''); // 아직 어떤식으로 넘겨줄지 미정
   const [writer, , handleWriter] = useInput('');
 
-  // if (personal_id === null && group_id === null) {
-  //   alert('유효하지 않은 접속입니다.');
-  //   // redirect 해야함
-  // }
+  if (id === null || id === undefined) {
+    alert('유효하지 않은 접속입니다.');
+    // redirect 해야함 -> 어디로?
+  }
   const handleConfirm = () => {
-    if (message === '') {
+    if (text === '') {
       alert('이어 쓸 스트링을 입력해주세요');
     } else if (writer === '') {
       alert('작성자명을 입력해주세요');
@@ -21,13 +21,20 @@ export default function Add() {
     const isConfirmed = true;
     if (isConfirmed) {
       const data = {
-        id: 1, // 실제 id값은 어떻게 할지?
-        message: message,
+        text: text,
         photo: photo,
         writer: writer,
       };
-      // send post api
-      // axiosInstance.post('/add', data);
+      axiosInstance
+        .post(`/board/${id}/content`, data)
+        .then((res) => {
+          console.log(res);
+        })
+        .catch((err) => {
+          if (err.response.status === 406) {
+            alert('올바르지 않은 입력입니다. 다시 작성해주세요.');
+          }
+        });
     }
   };
 
@@ -38,12 +45,12 @@ export default function Add() {
       </div>
       <textarea
         id="message"
-        value={message}
+        value={text}
         className=" m-1 h-fit w-96 rounded-lg bg-slate-200 p-2 text-lg outline-none"
         placeholder="내용을 입력해주세요"
         maxLength={1000}
         rows={5}
-        onChange={handleMessage}
+        onChange={handleText}
         onKeyDown={(e) => {
           if (e.currentTarget.value.length >= 1000) {
             alert('최대 1000자까지 입력 가능합니다.');

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 import useInput from '@/hooks/useInput';
 import { axiosInstance } from '@/utils/axios';
+import { useSearchParams } from 'next/navigation';
 
-export default function Add(id: { id: string }) {
+export default function Add() {
+  const searchParams = useSearchParams();
+  const id = searchParams.get('id');
+
   const [text, , handleText] = useInput('');
   const [photo, setPhoto] = useInput(''); // 아직 어떤식으로 넘겨줄지 미정
   const [writer, , handleWriter] = useInput('');

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,17 +1,17 @@
 'use client';
+import useInput from '@/hooks/useInput';
 // import { axiosInstance } from '@/utils/axios';
-import { useState } from 'react';
 
 export default function Add() {
-  const [message, setMessage] = useState<string>('');
-  const [photo, setPhoto] = useState<string>(''); // 아직 어떤식으로 넘겨줄지 미정
-  const [writer, setWriter] = useState<string>('');
+  const [message, , handleMessage] = useInput('');
+  const [photo, setPhoto] = useInput(''); // 아직 어떤식으로 넘겨줄지 미정
+  const [writer, , handleWriter] = useInput('');
 
   // if (personal_id === null && group_id === null) {
   //   alert('유효하지 않은 접속입니다.');
   //   // redirect 해야함
   // }
-  function handleConfirm() {
+  const handleConfirm = () => {
     if (message === '') {
       alert('이어 쓸 스트링을 입력해주세요');
     } else if (writer === '') {
@@ -29,7 +29,7 @@ export default function Add() {
       // send post api
       // axiosInstance.post('/add', data);
     }
-  }
+  };
 
   return (
     <>
@@ -38,13 +38,12 @@ export default function Add() {
       </div>
       <textarea
         id="message"
+        value={message}
         className=" m-1 h-fit w-96 rounded-lg bg-slate-200 p-2 text-lg outline-none"
         placeholder="내용을 입력해주세요"
         maxLength={1000}
         rows={5}
-        onChange={(e) => {
-          setMessage(e.currentTarget.value);
-        }}
+        onChange={handleMessage}
         onKeyDown={(e) => {
           if (e.currentTarget.value.length >= 1000) {
             alert('최대 1000자까지 입력 가능합니다.');
@@ -70,12 +69,11 @@ export default function Add() {
       <input
         type="text"
         id="writer"
+        value={writer}
         className="m-1 h-10 w-40 rounded-md bg-slate-200 px-2 outline-none"
         placeholder="익명"
         // maxLength={8}
-        onChange={(e) => {
-          setWriter(e.currentTarget.value);
-        }}
+        onChange={handleWriter}
       />
       <button
         type="button"

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+interface Id {
+  personal_id: number;
+  group_id: number;
+}
+
+export default function Add(props: Id) {
+  const [content, setContent] = useState<string>('');
+  const [writer, setWriter] = useState<string>('');
+  const [photo, setPhoto] = useState<string>(''); // 아직 어떤식으로 넘겨줄지 미정
+
+  return (
+    <>
+      <div id="photo">사진 입력</div>
+      <input
+        type="text"
+        id="content"
+        className="h-20 w-full bg-slate-200"
+        placeholder="내용을 입력해주세요"
+      />
+      <input
+        type="text"
+        id="writer"
+        className="h-20 w-20 bg-slate-200"
+        placeholder="익명"
+      />
+      <button type="button" id="done" className="h-20 w-full bg-slate-200">
+        작성 완료
+      </button>
+    </>
+  );
+}

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,11 +1,7 @@
 'use client';
 // import { axiosInstance } from '@/utils/axios';
 import { useState } from 'react';
-
-interface id {
-  personal_id: number | null;
-  group_id: number | null;
-}
+import { id } from '@/types/id';
 
 export default function Add(props: id) {
   const [message, setMessage] = useState<string>('');

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,23 +1,36 @@
 'use client';
+// import { axiosInstance } from '@/utils/axios';
 import { useState } from 'react';
 
-// export interface stringMessage {
-//   message: string;
-//   photo: string;
-//   writer: string;
-//   id: number | null;
-// }
+interface id {
+  personal_id: number | null;
+  group_id: number | null;
+}
 
-// export interface id {
-//     personal_id: number | null;
-//     group_id: number | null;
-//   }
-
-export default function Add() {
+export default function Add(props: id) {
   const [message, setMessage] = useState<string>('');
   const [photo, setPhoto] = useState<string>(''); // 아직 어떤식으로 넘겨줄지 미정
   const [writer, setWriter] = useState<string>('');
-  const [isDone, setIsDone] = useState<boolean>(false);
+
+  function handleConfirm() {
+    if (message === '') {
+      alert('이어 쓸 스트링을 입력해주세요');
+    } else if (writer === '') {
+      alert('작성자명을 입력해주세요');
+    }
+    //const { isConfirmed } = await useConfirm('작성한 글을 이어붙이시겠습니까?');
+    const isConfirmed = true;
+    if (isConfirmed) {
+      const data = {
+        id: props.personal_id,
+        message: message,
+        photo: photo,
+        writer: writer,
+      };
+      // send post api
+      // axiosInstance.post('/add', data);
+    }
+  }
 
   return (
     <>
@@ -30,13 +43,15 @@ export default function Add() {
         placeholder="내용을 입력해주세요"
         maxLength={1000}
         rows={5}
+        onChange={(e) => {
+          setMessage(e.currentTarget.value);
+        }}
         onKeyDown={(e) => {
-          if (e.currentTarget.value.length > 1000) {
-            e.preventDefault();
+          if (e.currentTarget.value.length >= 1000) {
             alert('최대 1000자까지 입력 가능합니다.');
+            e.preventDefault();
             e.currentTarget.value = e.currentTarget.value.slice(0, 1000);
           }
-          setMessage(e.currentTarget.value);
         }}
       />
       <form>
@@ -59,7 +74,7 @@ export default function Add() {
         className="m-1 h-10 w-40 rounded-md bg-slate-200 px-2 outline-none"
         placeholder="익명"
         // maxLength={8}
-        onKeyDown={(e) => {
+        onChange={(e) => {
           setWriter(e.currentTarget.value);
         }}
       />
@@ -67,24 +82,10 @@ export default function Add() {
         type="button"
         id="done"
         className="h-10 w-40 rounded-md bg-slate-200 "
-        onClick={() => setIsDone(true)}
+        onClick={handleConfirm}
       >
         작성 완료
       </button>
-      {isDone && (
-        <div className="fixed left-1/3 top-1/4 h-40 w-40 bg-slate-400">
-          모달창
-          <br />
-          <button
-            type="button"
-            onClick={() => {
-              setIsDone(false);
-            }}
-          >
-            닫기
-          </button>
-        </div>
-      )}
     </>
   );
 }

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -48,12 +48,20 @@ export default function Add() {
     textarea.style.height = 'auto';
     textarea.style.height = `${textarea.scrollHeight}px`;
   };
+  const onKeyDownMessage = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.currentTarget.value.length >= 1000) {
+      alert('최대 1000자까지 입력 가능합니다.');
+      e.preventDefault();
+      e.currentTarget.value = e.currentTarget.value.slice(0, 1000);
+    }
+  };
   return (
     <>
       <div id="title" className="content-center justify-center text-center">
         스트링캣을 이어서 작성
       </div>
             onChange={(e) => onChangeResize(e)}
+            onKeyDown={(e) => onKeyDownMessage(e)}
     </>
   );
 }

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 // import { axiosInstance } from '@/utils/axios';
 import { useState } from 'react';
-import { id } from '@/types/id';
 
-export default function Add(props: id) {
+export default function Add() {
   const [message, setMessage] = useState<string>('');
   const [photo, setPhoto] = useState<string>(''); // 아직 어떤식으로 넘겨줄지 미정
   const [writer, setWriter] = useState<string>('');
 
+  // if (personal_id === null && group_id === null) {
+  //   alert('유효하지 않은 접속입니다.');
+  //   // redirect 해야함
+  // }
   function handleConfirm() {
     if (message === '') {
       alert('이어 쓸 스트링을 입력해주세요');
@@ -18,7 +21,7 @@ export default function Add(props: id) {
     const isConfirmed = true;
     if (isConfirmed) {
       const data = {
-        id: props.personal_id,
+        id: 1, // 실제 id값은 어떻게 할지?
         message: message,
         photo: photo,
         writer: writer,

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -42,58 +42,18 @@ export default function Add() {
     }
   };
 
+  const onChangeResize = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    handleText(e);
+    const textarea: HTMLTextAreaElement = e.target;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  };
   return (
     <>
       <div id="title" className="content-center justify-center text-center">
         스트링캣을 이어서 작성
       </div>
-      <textarea
-        id="message"
-        value={text}
-        className=" m-1 h-fit w-96 rounded-lg bg-slate-200 p-2 text-lg outline-none"
-        placeholder="내용을 입력해주세요"
-        maxLength={1000}
-        rows={5}
-        onChange={handleText}
-        onKeyDown={(e) => {
-          if (e.currentTarget.value.length >= 1000) {
-            alert('최대 1000자까지 입력 가능합니다.');
-            e.preventDefault();
-            e.currentTarget.value = e.currentTarget.value.slice(0, 1000);
-          }
-        }}
-      />
-      <form>
-        <label
-          className="photo-label text-md mx-3 my-1 inline-block cursor-pointer"
-          htmlFor="photoImg"
-        >
-          사진 선택
-        </label>
-        <input
-          className="photo-input hidden"
-          type="file"
-          accept="image/*"
-          id="photoImg"
-        />
-      </form>
-      <input
-        type="text"
-        id="writer"
-        value={writer}
-        className="m-1 h-10 w-40 rounded-md bg-slate-200 px-2 outline-none"
-        placeholder="익명"
-        // maxLength={8}
-        onChange={handleWriter}
-      />
-      <button
-        type="button"
-        id="done"
-        className="h-10 w-40 rounded-md bg-slate-200 "
-        onClick={handleConfirm}
-      >
-        작성 완료
-      </button>
+            onChange={(e) => onChangeResize(e)}
     </>
   );
 }

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -1,35 +1,88 @@
 'use client';
-import axios from 'axios';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-interface Id {
-  personal_id: number;
-  group_id: number;
-}
+// export interface stringMessage {
+//   message: string;
+//   photo: string;
+//   writer: string;
+//   id: number | null;
+// }
 
-export default function Add(props: Id) {
-  const [content, setContent] = useState<string>('');
-  const [writer, setWriter] = useState<string>('');
+// export interface id {
+//     personal_id: number | null;
+//     group_id: number | null;
+//   }
+
+export default function Add() {
+  const [message, setMessage] = useState<string>('');
   const [photo, setPhoto] = useState<string>(''); // 아직 어떤식으로 넘겨줄지 미정
+  const [writer, setWriter] = useState<string>('');
+  const [isDone, setIsDone] = useState<boolean>(false);
 
   return (
     <>
-      <div id="photo">사진 입력</div>
-      <input
-        type="text"
-        id="content"
-        className="h-20 w-full bg-slate-200"
+      <div id="title">스트링캣을 이어서 작성</div>
+      <textarea
+        id="message"
+        className=" m-1 h-fit w-full rounded-lg bg-slate-200 p-2 text-lg outline-none"
         placeholder="내용을 입력해주세요"
+        maxLength={1000}
+        rows={5}
+        onKeyDown={(e) => {
+          if (e.currentTarget.value.length > 1000) {
+            e.preventDefault();
+            alert('최대 1000자까지 입력 가능합니다.');
+            e.currentTarget.value = e.currentTarget.value.slice(0, 1000);
+          }
+          setMessage(e.currentTarget.value);
+        }}
       />
+      <form>
+        <label
+          className="photo-label text-md mx-3 my-1 inline-block cursor-pointer"
+          htmlFor="photoImg"
+        >
+          사진 선택
+        </label>
+        <input
+          className="photo-input hidden"
+          type="file"
+          accept="image/*"
+          id="photoImg"
+        />
+      </form>
       <input
         type="text"
         id="writer"
-        className="h-20 w-20 bg-slate-200"
+        className="m-1 h-10 w-40 rounded-md bg-slate-200 px-2 outline-none"
         placeholder="익명"
+        // maxLength={8}
+        onKeyDown={(e) => {
+          setWriter(e.currentTarget.value);
+        }}
       />
-      <button type="button" id="done" className="h-20 w-full bg-slate-200">
+      <button
+        type="button"
+        id="done"
+        className="h-10 w-40 bg-slate-200"
+        onClick={() => setIsDone(true)}
+      >
         작성 완료
       </button>
+      {isDone && (
+        <div className="fixed left-1/3 top-1/4 h-40 w-40 bg-slate-400">
+          모달창
+          <br />
+          <button
+            type="button"
+            onClick={() => {
+              setIsDone(false);
+            }}
+          >
+            닫기
+          </button>
+        </div>
+      )}
     </>
   );
 }

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -17,7 +17,7 @@ export default function Add() {
     // redirect 해야함 -> main으로?
   }
 
-  const onClickConfirm = () => {
+  const handleClick = () => {
     if (text === '') {
       alert('이어 쓸 스트링을 입력해주세요');
     } else if (writer === '') {
@@ -44,19 +44,21 @@ export default function Add() {
     }
   };
 
-  const onChangeResize = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChangeResize = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     handleText(e);
     const textarea: HTMLTextAreaElement = e.target;
     textarea.style.height = 'auto';
     textarea.style.height = `${textarea.scrollHeight}px`;
   };
-  const onKeyDownMessage = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.currentTarget.value.length >= 1000) {
       alert('최대 1000자까지 입력 가능합니다.');
       e.preventDefault();
       e.currentTarget.value = e.currentTarget.value.slice(0, 1000);
     }
   };
+
   return (
     <>
       <div id="title" className="pl-2">
@@ -71,8 +73,8 @@ export default function Add() {
             className="max-h-96 w-full resize-none bg-[#FAFAFA] text-xl font-semibold outline-none placeholder:text-[#CACACA]"
             placeholder="내용을 입력해주세요"
             maxLength={1000}
-            onChange={(e) => onChangeResize(e)}
-            onKeyDown={(e) => onKeyDownMessage(e)}
+            onChange={(e) => handleChangeResize(e)}
+            onKeyDown={(e) => handleKeyDown(e)}
           />
           <div className="text-right">{text.length}/1000</div>
         </div>
@@ -105,7 +107,7 @@ export default function Add() {
           type="button"
           id="done"
           className="fixed bottom-8 h-12 w-80 bg-[#CCCCCC] text-xl text-white"
-          onClick={onClickConfirm}
+          onClick={handleClick}
         >
           완료
         </button>

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -10,18 +10,20 @@ export default function Add() {
   const [text, , handleText] = useInput('');
   const [photo, setPhoto] = useInput(''); // 아직 어떤식으로 넘겨줄지 미정
   const [writer, , handleWriter] = useInput('');
+  // const [modal, setModal] = useRecoilState(modalState);
 
   if (id === null || id === undefined) {
     alert('유효하지 않은 접속입니다.');
-    // redirect 해야함 -> 어디로?
+    // redirect 해야함 -> main으로?
   }
-  const handleConfirm = () => {
+
+  const onClickConfirm = () => {
     if (text === '') {
       alert('이어 쓸 스트링을 입력해주세요');
     } else if (writer === '') {
       alert('작성자명을 입력해주세요');
     }
-    //const { isConfirmed } = await useConfirm('작성한 글을 이어붙이시겠습니까?');
+    //const isConfirmed = await useConfirm('작성한 글을 이어붙이시겠습니까?', setModal);
     const isConfirmed = true;
     if (isConfirmed) {
       const data = {
@@ -57,11 +59,57 @@ export default function Add() {
   };
   return (
     <>
-      <div id="title" className="content-center justify-center text-center">
-        스트링캣을 이어서 작성
+      <div id="title" className="pl-2">
+        strcat(*,*)
       </div>
+      <div className="mt-10 flex flex-col items-center justify-center">
+        <div className="w-80">
+          <textarea
+            id="message"
+            value={text}
+            rows={1}
+            className="max-h-96 w-full resize-none bg-[#FAFAFA] text-xl font-semibold outline-none placeholder:text-[#CACACA]"
+            placeholder="내용을 입력해주세요"
+            maxLength={1000}
             onChange={(e) => onChangeResize(e)}
             onKeyDown={(e) => onKeyDownMessage(e)}
+          />
+          <div className="text-right">{text.length}/1000</div>
+        </div>
+        <div className="mt-2 flex w-80 justify-end">
+          <input
+            type="text"
+            id="writer"
+            value={writer}
+            className="h-8 w-20 bg-[#FAFAFA] px-2 text-center outline-none placeholder:text-[#CACACA]"
+            placeholder="익명"
+            // maxLength={8}
+            onChange={handleWriter}
+          />
+        </div>
+        <form>
+          <label
+            className="photo-label text-md mx-3 my-1 inline-block cursor-pointer"
+            htmlFor="photoImg"
+          >
+            사진 선택
+          </label>
+          <input
+            className="photo-input hidden"
+            type="file"
+            accept="image/*"
+            id="photoImg"
+          />
+        </form>
+        <button
+          type="button"
+          id="done"
+          className="fixed bottom-8 h-12 w-80 bg-[#CCCCCC] text-xl text-white"
+          onClick={onClickConfirm}
+        >
+          완료
+        </button>
+      </div>
     </>
   );
 }

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -21,10 +21,12 @@ export default function Add() {
 
   return (
     <>
-      <div id="title">스트링캣을 이어서 작성</div>
+      <div id="title" className="content-center justify-center text-center">
+        스트링캣을 이어서 작성
+      </div>
       <textarea
         id="message"
-        className=" m-1 h-fit w-full rounded-lg bg-slate-200 p-2 text-lg outline-none"
+        className=" m-1 h-fit w-96 rounded-lg bg-slate-200 p-2 text-lg outline-none"
         placeholder="내용을 입력해주세요"
         maxLength={1000}
         rows={5}
@@ -64,7 +66,7 @@ export default function Add() {
       <button
         type="button"
         id="done"
-        className="h-10 w-40 bg-slate-200"
+        className="h-10 w-40 rounded-md bg-slate-200 "
         onClick={() => setIsDone(true)}
       >
         작성 완료

--- a/src/hooks/useInput.tsx
+++ b/src/hooks/useInput.tsx
@@ -1,0 +1,13 @@
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
+
+const useInput = <T = any,>(
+  initialData: T,
+): [T, Dispatch<SetStateAction<T>>, (e: any) => void] => {
+  const [value, setValue] = useState(initialData);
+  const handler = useCallback((e: any) => {
+    setValue(e.target.value);
+  }, []);
+  return [value, setValue, handler];
+};
+
+export default useInput;

--- a/src/types/id.ts
+++ b/src/types/id.ts
@@ -1,4 +1,4 @@
-export interface id {
+export default interface id {
   personal_id: number | null;
   group_id: number | null;
 }

--- a/src/types/id.ts
+++ b/src/types/id.ts
@@ -1,0 +1,4 @@
+export interface id {
+  personal_id: number | null;
+  group_id: number | null;
+}


### PR DESCRIPTION
# Describe your changes
- 글 작성에 필요한 textarea, 사진 파일 입력, 작성자 입력, 작성완료 버튼을 배치했습니다.
- 간단한 스타일을 적용했습니다. 아직 디자인 시안이 확정되기 이전이므로, 보기에 무리가 없을 정도로만 구현했습니다.
- 각 태그에서 필요한 동적이벤트를 구현했습니다.
  - onChange이벤트 및 textarea의 1000자 제한
  - 유효성 검사 구현
- 기선님이 구현중이신 모달파트에서 useConfirm이 Promise를 반환하고, 그 내부 값으로 true 또는 false를 가지는 것으로 변경됨에 따라, modal호출부를 변경했습니다.
  - isConfirmed의 값이 true일 경우 api 호출예정
  - false일 경우 미정
- npm run build후 오류가 나는 부분이 있어, 수정했습니다.

# Issue number and link
- #15

<img width="338" alt="Screenshot 2023-11-08 at 5 14 56 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/73814221-7983-4337-800f-0fdc7f52b407">


# review 이후
- useInput훅을 도입했습니다.
- textarea의 height를 작성한 글에 맞춰 늘리는 기능을 추가했습니다.
- 이벤트 handler의 이름규칙에 맞게 변경했습니다. 
- 기선님의 modal 풀리퀘가 아직 merge이전 상태라 주석으로 변경사항을 남겼습니다. 
- 1차 디자인 시안에 따라 css를 변경했습니다. 
- [next.js search-params](https://nextjs.org/docs/app/api-reference/functions/use-search-params)
   - 이 방식으로 params를 넘겨줘서, url을 http://localhost:3001/add?id=17 이런식으로 접속해야 페이지를 볼 수 있습니다.

# Screen Capture
<img width="341" alt="Screenshot 2023-11-13 at 6 24 16 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/4f9df1e1-e835-4fbb-8588-305693dc8d57">
