### PR TITLE
[Fix] Drawer & Header 오류 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   return (
     <html className="h-full">
       <body className="h-full">
-        <div className="m-auto h-full max-w-md font-sans">
+        <div className="m-auto h-full max-w-[calc(100vh*0.6)] font-sans">
           <RecoilRoot>
             <Modal />
             {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,9 +10,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html>
-      <body>
-        <div className="font-sans m-auto h-full max-w-[calc(100vh*0.6)]">
+    <html className="h-full">
+      <body className="h-full">
+        <div className="m-auto h-full max-w-md font-sans">
           <RecoilRoot>
             <Modal />
             {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <>
+    <div className="relative h-full w-full">
       <Drawer />
       <StrcatHeader />
       <div className="m-6">
@@ -49,6 +49,6 @@ export default function Home() {
           를 누르면 여러 문자열을 한 그룹으로 관리할 수 있어요. 주렁주렁~
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="relative h-full w-full">
+    <>
       <Drawer />
       <StrcatHeader />
       <div className="m-6">
@@ -49,6 +49,6 @@ export default function Home() {
           를 누르면 여러 문자열을 한 그룹으로 관리할 수 있어요. 주렁주렁~
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/component/Drawer.tsx
+++ b/src/component/Drawer.tsx
@@ -40,7 +40,7 @@ export default function Drawer() {
   }, []);
   const [, setDrawer] = useRecoilState(drawerState);
 
-  const handleBackground = (e: any) => {
+  const handleBackground = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
     setDrawer(false);
   };

--- a/src/component/Drawer.tsx
+++ b/src/component/Drawer.tsx
@@ -38,10 +38,16 @@ export default function Drawer() {
         console.log(err);
       });
   }, []);
+  const [, setDrawer] = useRecoilState(drawerState);
 
+  const handleBackground = (e: any) => {
+    console.log(e);
+    if (e.target !== e.currentTarget) return;
+    setDrawer(false);
+  };
   return (
     drawer && (
-      <div className="fixed right-0 top-0 z-20 h-full w-[300px] items-center bg-black">
+      <div className="absolute right-0 top-0 z-20 h-full w-[300px] bg-black text-white">
         <div className="flex h-[123px] w-full justify-start">
           <Image
             src="/ProfileImg.svg"
@@ -92,7 +98,7 @@ export default function Drawer() {
           <div className="absolute bottom-0 w-full px-[24px]">
             <div className="h-[53px] w-full">
               <DrawerItem
-                title="버전 정보?"
+                title="이용약관"
                 alt="version"
                 icon="/VersionIcon.svg"
               />

--- a/src/component/Drawer.tsx
+++ b/src/component/Drawer.tsx
@@ -61,20 +61,24 @@ export default function Drawer() {
             />
           </div>
           <div className="flex flex-col items-center text-white">
-            <div className="flex h-[53px] w-full items-center justify-between px-[24px]">
+            <div
+              className="flex h-[53px] w-full items-center justify-between px-[24px]"
+              onClick={() => setDropList(!dropList)}
+            >
               <DrawerItem
                 title="내 스트링캣"
                 alt="personalStrCat"
                 icon="/StrCatIcon.svg"
               />
-              <Image
-                src={dropList ? '/ListDownButton.svg' : '/ListUpButton.svg'}
-                width={24}
-                height={24}
-                alt="dropList"
-                className="ml-[12px]"
-                onClick={() => setDropList(!dropList)}
-              />
+              {personalList.length != 0 && (
+                <Image
+                  src={dropList ? '/ListDownButton.svg' : '/ListUpButton.svg'}
+                  width={24}
+                  height={24}
+                  alt="dropList"
+                  className="ml-[12px]"
+                />
+              )}
             </div>
             {dropList && (
               <div className="flex w-full flex-col">
@@ -83,7 +87,10 @@ export default function Drawer() {
                 )}
               </div>
             )}
-            <div className="flex h-[53px] w-full items-center justify-between px-[24px]">
+            <div
+              className="flex h-[53px] w-full items-center justify-between px-[24px]"
+              onClick={() => setGroupDropList(!groupDropList)}
+            >
               <DrawerItem
                 title="그룹 스트링캣"
                 alt="groupStrCat"
@@ -96,7 +103,6 @@ export default function Drawer() {
                 width={24}
                 height={24}
                 alt="groupDropList"
-                onClick={() => setGroupDropList(!groupDropList)}
               />
             </div>
             {groupDropList && (

--- a/src/component/Drawer.tsx
+++ b/src/component/Drawer.tsx
@@ -41,81 +41,89 @@ export default function Drawer() {
   const [, setDrawer] = useRecoilState(drawerState);
 
   const handleBackground = (e: any) => {
-    console.log(e);
     if (e.target !== e.currentTarget) return;
     setDrawer(false);
   };
   return (
     drawer && (
-      <div className="absolute right-0 top-0 z-20 h-full w-[300px] bg-black text-white">
-        <div className="flex h-[123px] w-full justify-start">
-          <Image
-            src="/ProfileImg.svg"
-            width={72}
-            height={72}
-            alt="profileImg"
-            className="m-[24px]"
-          />
-        </div>
-        <div className="flex flex-col items-center text-white">
-          <div className="flex h-[53px] w-full items-center justify-between px-[24px]">
-            <DrawerItem
-              title="내 스트링캣"
-              alt="personalStrCat"
-              icon="/StrCatIcon.svg"
-            />
+      <div
+        className="fixed z-20 h-full w-full max-w-[calc(100vh*0.6)]"
+        onClick={handleBackground}
+      >
+        <div className="absolute right-0 z-20 h-full w-[300px] bg-black text-white">
+          <div className="flex h-[123px] w-full justify-start">
             <Image
-              src={dropList ? '/ListDownButton.svg' : '/ListUpButton.svg'}
-              width={24}
-              height={24}
-              alt="dropList"
-              className="ml-[12px]"
-              onClick={() => setDropList(!dropList)}
+              src="/ProfileImg.svg"
+              width={72}
+              height={72}
+              alt="profileImg"
+              className="m-[24px]"
             />
           </div>
-          {dropList && (
-            <div className="flex w-full flex-col">
-              {personalList && (
-                <DropListItem list={personalList} category="personal" />
-              )}
-            </div>
-          )}
-          <div className="flex h-[53px] w-full items-center justify-between px-[24px]">
-            <DrawerItem
-              title="그룹 스트링캣"
-              alt="groupStrCat"
-              icon="/StrCatIcon.svg"
-            />
-            <Image
-              src={groupDropList ? '/ListDownButton.svg' : '/ListUpButton.svg'}
-              width={24}
-              height={24}
-              alt="groupDropList"
-              onClick={() => setGroupDropList(!groupDropList)}
-            />
-          </div>
-          {groupDropList && <DropListItem list={groupList} category="group" />}
-          <div className="absolute bottom-0 w-full px-[24px]">
-            <div className="h-[53px] w-full">
+          <div className="flex flex-col items-center text-white">
+            <div className="flex h-[53px] w-full items-center justify-between px-[24px]">
               <DrawerItem
-                title="이용약관"
-                alt="version"
-                icon="/VersionIcon.svg"
+                title="내 스트링캣"
+                alt="personalStrCat"
+                icon="/StrCatIcon.svg"
+              />
+              <Image
+                src={dropList ? '/ListDownButton.svg' : '/ListUpButton.svg'}
+                width={24}
+                height={24}
+                alt="dropList"
+                className="ml-[12px]"
+                onClick={() => setDropList(!dropList)}
               />
             </div>
-            <div className="h-[53px] w-full">
+            {dropList && (
+              <div className="flex w-full flex-col">
+                {personalList && (
+                  <DropListItem list={personalList} category="personal" />
+                )}
+              </div>
+            )}
+            <div className="flex h-[53px] w-full items-center justify-between px-[24px]">
               <DrawerItem
-                title="Man Strcat"
-                alt="notify"
-                icon="/NotifyIcon.svg"
+                title="그룹 스트링캣"
+                alt="groupStrCat"
+                icon="/StrCatIcon.svg"
+              />
+              <Image
+                src={
+                  groupDropList ? '/ListDownButton.svg' : '/ListUpButton.svg'
+                }
+                width={24}
+                height={24}
+                alt="groupDropList"
+                onClick={() => setGroupDropList(!groupDropList)}
               />
             </div>
-            <div className="h-[53px] w-full">
-              <DrawerItem
-                title="로그아웃"
-                alt="logout"
-                icon="/LogoutIcon.svg"
-              />
+            {groupDropList && (
+              <DropListItem list={groupList} category="group" />
+            )}
+            <div className="absolute bottom-0 w-full px-[24px]">
+              <div className="h-[53px] w-full">
+                <DrawerItem
+                  title="이용약관"
+                  alt="version"
+                  icon="/VersionIcon.svg"
+                />
+              </div>
+              <div className="h-[53px] w-full">
+                <DrawerItem
+                  title="Man Strcat"
+                  alt="notify"
+                  icon="/NotifyIcon.svg"
+                />
+              </div>
+              <div className="h-[53px] w-full">
+                <DrawerItem
+                  title="로그아웃"
+                  alt="logout"
+                  icon="/LogoutIcon.svg"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/component/StrcatHeader.tsx
+++ b/src/component/StrcatHeader.tsx
@@ -26,8 +26,8 @@ export default function StrcatHeader() {
       <Link href="/">
         <Image
           src="/Logo.svg"
-          width={128}
-          height={25}
+          width={89}
+          height={39}
           alt="logo"
           priority
           loading="eager"
@@ -37,8 +37,8 @@ export default function StrcatHeader() {
       {isLogin ? (
         <Image
           src="/ProfileImg.svg"
-          width={40}
-          height={10}
+          width={24}
+          height={24}
           alt="profileImg"
           loading="eager"
           priority

--- a/src/component/StrcatHeader.tsx
+++ b/src/component/StrcatHeader.tsx
@@ -24,7 +24,14 @@ export default function StrcatHeader() {
   return (
     <div className="flex h-[56px] flex-row items-center justify-between bg-black px-[24px]">
       <Link href="/">
-        <Image src="/Logo.svg" width={128} height={25} alt="logo" />
+        <Image
+          src="/Logo.svg"
+          width={128}
+          height={25}
+          alt="logo"
+          priority
+          loading="eager"
+        />
       </Link>
       <div className="basis-4/6"></div>
       {isLogin ? (
@@ -33,6 +40,8 @@ export default function StrcatHeader() {
           width={40}
           height={10}
           alt="profileImg"
+          loading="eager"
+          priority
           onClick={() => setDrawer(true)}
         />
       ) : (
@@ -43,7 +52,9 @@ export default function StrcatHeader() {
               width={74}
               height={34}
               alt="login"
+              loading="eager"
               className="absolute inset-0"
+              priority
             />
             <span className="absolute inset-0 flex items-center justify-center text-white">
               로그인

--- a/src/component/StrcatHeader.tsx
+++ b/src/component/StrcatHeader.tsx
@@ -22,7 +22,7 @@ export default function StrcatHeader() {
   }, []);
 
   return (
-    <div className="flex h-[56px] flex-row items-center bg-black px-[24px]">
+    <div className="flex h-[56px] flex-row items-center justify-between bg-black px-[24px]">
       <Link href="/">
         <Image src="/Logo.svg" width={128} height={25} alt="logo" />
       </Link>


### PR DESCRIPTION
# Describe your changes
- 드로어의 위치를 변경했습니다. 이 과정에서 app/ layout.tsx을 수정했습니다. 
   - layout.tsx : html, body의 class를 부여하고, h-full 옵션을 넣었습니다.
- header의 로고, 프로필 이미지의 사이즈를 figma와 맞게 조정하고, 프로필 이미지 위치가 좌측으로 이동해 있어 justify-between옵션으로 위치 재지정했습니다. 
- 드로어를 열었을 때, 드로어 이외의 공간 클릭시 드로어가 닫히는 기능을 추가했습니다.
    - 이 코드는 @Arkingco 기선님의 modal/index.tsx의 handlebackground 핸들러를 참고한건데, util함수로 분리하는 거 어떨까요?
- 지수님께서 어제 의견주신 디자인을 반영했습니다.
     - 드로어의 droplist가 열리는 터치영역은 내스트링캣 프레임 전부로 변경했습니다.
     - 그리고 만든 스트링캣이 없을 경우 drop button이 없는것으로 만들었습니다.
- 어제 백엔드 통합테스트에서, 기선님께서 이미지 로딩시 작았다가 커지는 부분을 문제제기해주셨습니다. 
   - 찾아보니 이미지 로딩시 lazy하게 받으면 그럴 수 있다고 해서, loading: eager속성, priority속성으로 먼저 이미지를 로딩하도록 만들었습니다. 

## Screen Capture

<img width="350" alt="Screenshot 2023-11-24 at 3 53 10 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/b983282d-064a-4c9d-a55d-3113e187054e">
<img width="350" alt="Screenshot 2023-11-24 at 3 53 04 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/922cb6cc-1b0b-46ad-9857-b81c02862d4b">

# Issue number and link
- #27 
- #66 