### PR TITLE
[feat] button 스타일적용, 그룹페이지 버튼 적용

### DIFF
--- a/src/app/api/group/data.json
+++ b/src/app/api/group/data.json
@@ -1,25 +1,11 @@
 {
-  "titleData": {
-    "title": "친애하는 친구에게",
-    "backgroundColor": "#FFDAB9",
-    "boards": [
-      {
-        "id": 1,
-        "title": "소중한 인연을 지켜줘",
-        "backgroundColor": "#87CEEB"
-      },
-      {
-        "id": 2,
-        "title": "감사의 마음을 전해줘",
-        "backgroundColor": "#90EE90"
-      }
-    ]
-  },
-  "contentData": [
+  "isOwner": true,
+  "title": "hello~~",
+  "boards": [
     {
       "id": 1,
       "title": "소중한 인연을 지켜줘",
-      "backgroundColor": "#87CEEB",
+      "theme": "calm",
       "content": [
         {
           "id": 1,
@@ -44,7 +30,7 @@
     {
       "id": 2,
       "title": "감사의 마음을 전해줘",
-      "backgroundColor": "#90EE90",
+      "theme": "green",
       "content": [
         {
           "id": 4,

--- a/src/app/api/personal/data.json
+++ b/src/app/api/personal/data.json
@@ -1,8 +1,8 @@
 {
   "id": 1,
   "title": "Sample Board",
-  "backgroundColor": "#ffffff",
-  "contents": [
+  "theme": "green",
+  "content": [
     {
       "id": 1,
       "text": "즐거운 순간을 함께하며 행복한 기억 만들기를 기대해요.n",

--- a/src/app/group/[id]/export/page.tsx
+++ b/src/app/group/[id]/export/page.tsx
@@ -92,6 +92,7 @@ export default function Export() {
           ))}
         </div>
         <BottomButton
+          color="white"
           name="저장하기"
           width="w-[370px]"
           onClickHandler={handleSave}

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -11,6 +11,7 @@ import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
 import BottomButton from '@/component/BottomButton';
 import { observeState } from '@/recoil/observe';
+import StrcatGroupTitle from '@/component/StrcatGroupTitle';
 
 export default function Home() {
   const [title, setTitle] = useState<string | null>();
@@ -51,19 +52,11 @@ export default function Home() {
         <div>
           {boards.map((board: board) => {
             return (
-              <div
+              <StrcatGroupTitle
                 key={board.id}
-                className={`my-[32px] ${themeObj[board.theme].BgColor}`}
-                onClick={() => scrollToId(board.id)}
-              >
-                <p
-                  className={`cursor-pointer text-xl ${
-                    themeObj[board.theme].DefaultFontColor
-                  }`}
-                >
-                  {board.title}
-                </p>
-              </div>
+                board={board}
+                scrollToId={scrollToId}
+              />
             );
           })}
         </div>

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -68,7 +68,7 @@ export default function Home() {
             );
           })}
         </div>
-        <div className=" mb-[500px] text-justify">
+        <div className="pb-[500px] text-justify">
           {boardsConetent.map((board) => {
             return (
               <StrcatBoard
@@ -96,11 +96,10 @@ export default function Home() {
               name="글 작성"
               width="w-full"
               onClickHandler={handleClick}
-              disabled={false}
+              disabled={!observe.boardId}
             />
           </div>
         )}
-        {!isAdd && <ContentPhoto />}
         {!isAdd && <ContentPhoto />}
       </div>
     </>

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -6,17 +6,15 @@ import StrcatBoard from '@/component/StrcatBoard';
 import { board } from '@/types/boards';
 import ContentPhoto from '@/component/ContentPhoto';
 import { useRecoilState } from 'recoil';
-import { themeState } from '@/recoil/theme';
+import { themeObj, themeState } from '@/recoil/theme';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
-import Add from '@/component/Add';
 import BottomButton from '@/component/BottomButton';
 import { observeState } from '@/recoil/observe';
 
 export default function Home() {
   const [title, setTitle] = useState<string | null>();
-  const [boardsTitle, setBoardsTitle] = useState<board[]>([]);
-  const [boardsConetent, setBoardsContent] = useState<board[]>([]);
+  const [boards, setBoards] = useState<board[]>([]);
   const [isAdd, setIsAdd] = useState(false);
   const [theme] = useRecoilState(themeState);
   const itemsRef = useRef(new Map());
@@ -37,9 +35,8 @@ export default function Home() {
     axiosInstance
       .get(`/api/group`)
       .then((data) => {
-        setTitle(data.data.titleData.title);
-        setBoardsTitle(data.data.titleData.boards);
-        setBoardsContent(data.data.contentData);
+        setBoards(data.data.boards);
+        setTitle(data.data.title);
       })
       .catch((error) => {});
   }, []);
@@ -47,20 +44,22 @@ export default function Home() {
     <>
       <Drawer />
       <StrcatHeader />
-      <div className={`relative w-full p-[24px] ${theme.BgColor}`}>
+      <div className={`relative w-full py-[24px] ${theme.BgColor}`}>
         <div className="mb-[20px]">
           <h1 className={`${theme.DefaultFontColor} text-4xl`}>{title}</h1>
         </div>
         <div>
-          {boardsTitle.map((board: board) => {
+          {boards.map((board: board) => {
             return (
               <div
                 key={board.id}
-                className="my-[32px]"
+                className={`my-[32px] ${themeObj[board.theme].BgColor}`}
                 onClick={() => scrollToId(board.id)}
               >
                 <p
-                  className={`cursor-pointer text-xl ${theme.DefaultFontColor}`}
+                  className={`cursor-pointer text-xl ${
+                    themeObj[board.theme].DefaultFontColor
+                  }`}
                 >
                   {board.title}
                 </p>
@@ -69,11 +68,12 @@ export default function Home() {
           })}
         </div>
         <div className="pb-[500px] text-justify">
-          {boardsConetent.map((board) => {
+          {boards.map((board) => {
             return (
               <StrcatBoard
+                theme={board.theme}
                 setIsAdd={setIsAdd}
-                isAdd={isAdd} //그룹페이지에서 글작성버튼은 설정되지않은 상태인데, 타입에러 방지를 위해 일단 추가하였습니다
+                isAdd={isAdd}
                 ref={(node) => {
                   const map = getMap();
                   if (node) {
@@ -107,14 +107,14 @@ export default function Home() {
               disabled={false}
             />
             <BottomButton
-              color={`bg-[#7CED43]`}
+              color={`bg-strcat-green`}
               name="만들기"
               width="basis-1/4"
               onClickHandler={handleClick}
               disabled={false}
             />
             <BottomButton
-              color={`bg-[#6CD8ED]`}
+              color={`bg-strcat-cyan`}
               name="글 작성"
               width="basis-1/4"
               onClickHandler={handleClick}

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -6,7 +6,7 @@ import StrcatBoard from '@/component/StrcatBoard';
 import { board } from '@/types/boards';
 import ContentPhoto from '@/component/ContentPhoto';
 import { useRecoilState } from 'recoil';
-import { themeObj, themeState } from '@/recoil/theme';
+import { themeState } from '@/recoil/theme';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
 import BottomButton from '@/component/BottomButton';
@@ -72,14 +72,11 @@ export default function Home() {
           {boards.map((board) => {
             return (
               <StrcatBoard
-                theme={board.theme}
                 setIsAdd={setIsAdd}
                 isAdd={isAdd}
                 ref={(node) => setMap(node, board)}
                 key={board.id}
-                boardId={board.id}
-                title={board.title}
-                data={board.content}
+                board={board}
               />
             );
           })}

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -9,6 +9,9 @@ import { useRecoilState } from 'recoil';
 import { themeState } from '@/recoil/theme';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
+import Add from '@/component/Add';
+import BottomButton from '@/component/BottomButton';
+import { observeState } from '@/recoil/observe';
 
 export default function Home() {
   const [title, setTitle] = useState<string | null>();
@@ -17,11 +20,15 @@ export default function Home() {
   const [isAdd, setIsAdd] = useState(false);
   const [theme] = useRecoilState(themeState);
   const itemsRef = useRef(new Map());
+  const [observe] = useRecoilState(observeState);
   const scrollToId = (itemId: number) => {
     const map = getMap();
     const node = map.get(itemId);
     const offset = node.offsetTop;
     window.scrollTo({ top: offset, behavior: 'smooth' });
+  };
+  const handleClick = () => {
+    setIsAdd(true);
   };
   const getMap = () => {
     return itemsRef.current;
@@ -65,6 +72,7 @@ export default function Home() {
           {boardsConetent.map((board) => {
             return (
               <StrcatBoard
+                setIsAdd={setIsAdd}
                 isAdd={isAdd} //그룹페이지에서 글작성버튼은 설정되지않은 상태인데, 타입에러 방지를 위해 일단 추가하였습니다
                 ref={(node) => {
                   const map = getMap();
@@ -82,7 +90,18 @@ export default function Home() {
             );
           })}
         </div>
-        <ContentPhoto />
+        {!isAdd && (
+          <div className="sticky bottom-5 w-full">
+            <BottomButton
+              name="글 작성"
+              width="w-full"
+              onClickHandler={handleClick}
+              disabled={false}
+            />
+          </div>
+        )}
+        {!isAdd && <ContentPhoto />}
+        {!isAdd && <ContentPhoto />}
       </div>
     </>
   );

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -91,10 +91,32 @@ export default function Home() {
           })}
         </div>
         {!isAdd && (
-          <div className="sticky bottom-5 w-full">
+          <div className="sticky bottom-5 flex w-full">
             <BottomButton
+              color={`bg-white`}
+              name="저장"
+              width="basis-1/4"
+              onClickHandler={handleClick}
+              disabled={false}
+            />
+            <BottomButton
+              color={`bg-white`}
+              name="공유"
+              width="basis-1/4"
+              onClickHandler={handleClick}
+              disabled={false}
+            />
+            <BottomButton
+              color={`bg-[#7CED43]`}
+              name="만들기"
+              width="basis-1/4"
+              onClickHandler={handleClick}
+              disabled={false}
+            />
+            <BottomButton
+              color={`bg-[#6CD8ED]`}
               name="글 작성"
-              width="w-full"
+              width="basis-1/4"
               onClickHandler={handleClick}
               disabled={!observe.boardId}
             />

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -12,6 +12,7 @@ import StrcatHeader from '@/component/StrcatHeader';
 import BottomButton from '@/component/BottomButton';
 import { observeState } from '@/recoil/observe';
 import StrcatGroupTitle from '@/component/StrcatGroupTitle';
+import { scrollToAdd, setMap } from '@/utils/scrollTo';
 
 export default function Home() {
   const [title, setTitle] = useState<string | null>();
@@ -21,24 +22,14 @@ export default function Home() {
   const itemsRef = useRef(new Map());
   const [observe] = useRecoilState(observeState);
   const scrollToId = (itemId: number) => {
-    const map = getMap();
+    const map = itemsRef.current;
     const node = map.get(itemId);
     const offset = node.offsetTop;
     window.scrollTo({ top: offset, behavior: 'smooth' });
   };
   const handleClick = () => {
     setIsAdd(true);
-  };
-  const getMap = () => {
-    return itemsRef.current;
-  };
-  const setMap = (node: HTMLDivElement | null, board: board) => {
-    const map = getMap();
-    if (node) {
-      map.set(board.id, node);
-    } else {
-      map.delete(board.id);
-    }
+    scrollToAdd(observe.boardId, itemsRef);
   };
   useEffect(() => {
     axiosInstance
@@ -74,7 +65,7 @@ export default function Home() {
               <StrcatBoard
                 setIsAdd={setIsAdd}
                 isAdd={isAdd}
-                ref={(node) => setMap(node, board)}
+                ref={(node) => setMap(node, board, itemsRef)}
                 key={board.id}
                 board={board}
               />

--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -32,6 +32,14 @@ export default function Home() {
   const getMap = () => {
     return itemsRef.current;
   };
+  const setMap = (node: HTMLDivElement | null, board: board) => {
+    const map = getMap();
+    if (node) {
+      map.set(board.id, node);
+    } else {
+      map.delete(board.id);
+    }
+  };
   useEffect(() => {
     axiosInstance
       .get(`/api/group`)
@@ -67,14 +75,7 @@ export default function Home() {
                 theme={board.theme}
                 setIsAdd={setIsAdd}
                 isAdd={isAdd}
-                ref={(node) => {
-                  const map = getMap();
-                  if (node) {
-                    map.set(board.id, node);
-                  } else {
-                    map.delete(board.id);
-                  }
-                }}
+                ref={(node) => setMap(node, board)}
                 key={board.id}
                 boardId={board.id}
                 title={board.title}

--- a/src/app/personal/[id]/export/page.tsx
+++ b/src/app/personal/[id]/export/page.tsx
@@ -79,6 +79,7 @@ export default function Export() {
           ))}
         </div>
         <BottomButton
+          color={'white'}
           name="저장하기"
           width="w-full"
           onClickHandler={handleSave}

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -62,7 +62,6 @@ export default function Home() {
               onClickHandler={() => router.push('./export')}
               disabled={false}
               color={`bg-white`}
-              bgColor={`${themeObj[board.theme].BgColor}`}
             />
             <BottomButton
               name="공유"
@@ -70,7 +69,6 @@ export default function Home() {
               onClickHandler={() => router.push('./summary')}
               disabled={false}
               color={`bg-strcat-green`}
-              bgColor={`${themeObj[board.theme].BgColor}`}
             />
             <BottomButton
               name="글 작성"
@@ -78,7 +76,6 @@ export default function Home() {
               onClickHandler={handleClick}
               disabled={!observe.boardId}
               color={`bg-strcat-cyan`}
-              bgColor={`${themeObj[board.theme].BgColor}`}
             />
           </div>
         )}

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -12,6 +12,7 @@ import { themeState } from '@/recoil/theme';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
 import { observeState } from '@/recoil/observe';
+import { useRouter } from 'next/navigation';
 
 export default function Home() {
   const [title, setTitle] = useState<string>('');
@@ -21,6 +22,7 @@ export default function Home() {
   const [theme] = useRecoilState(themeState);
   const itemsRef = useRef(new Map());
   const [observe] = useRecoilState(observeState);
+  const router = useRouter();
 
   const scrollToId = (itemId: number) => {
     const map = getMap();
@@ -72,12 +74,27 @@ export default function Home() {
           setIsAdd={setIsAdd}
         />
         {!isAdd && (
-          <div className="sticky bottom-5 w-full">
+          <div className="sticky bottom-5 flex w-full">
+            <BottomButton
+              name="저장"
+              width="basis-1/5"
+              onClickHandler={() => router.push('./export')}
+              disabled={false}
+              color={`bg-white`}
+            />
+            <BottomButton
+              name="공유"
+              width="basis-1/5"
+              onClickHandler={() => router.push('./summary')}
+              disabled={false}
+              color={`bg-[#7CED43]`}
+            />
             <BottomButton
               name="글 작성"
-              width="w-full"
+              width="basis-3/5"
               onClickHandler={handleClick}
               disabled={!observe.boardId}
+              color={`bg-[#6CD8ED]`}
             />
           </div>
         )}

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -2,21 +2,20 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { axiosInstance } from '@/utils/axios';
-import { content } from '@/types/content';
 import StrcatBoard from '@/component/StrcatBoard';
-import Add from '@/component/Add';
 import BottomButton from '@/component/BottomButton';
 import ContentPhoto from '@/component/ContentPhoto';
 import { useRecoilState } from 'recoil';
-import { themeObj, themeState } from '@/recoil/theme';
+import { themeObj } from '@/recoil/theme';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
 import { observeState } from '@/recoil/observe';
 import { useRouter } from 'next/navigation';
 import { board } from '@/types/boards';
+import { scrollToAdd, setMap } from '@/utils/scrollTo';
 
 export default function Home() {
-  const [boards, setBoards] = useState<board>({
+  const [board, setBoard] = useState<board>({
     id: 0,
     title: '',
     theme: 'strcat',
@@ -26,29 +25,18 @@ export default function Home() {
   const itemsRef = useRef(new Map());
   const [observe] = useRecoilState(observeState);
   const router = useRouter();
-
-  const scrollToId = (itemId: number) => {
-    const map = getMap();
-    const node = map.get(itemId);
-    const height = node.offsetHeight;
-    const offset = node.offsetTop + height - 500; // 하단의 여백을 500만큼 줬으므로 그만큼 빼준다.
-    window.scrollTo({ top: offset, behavior: 'smooth' });
-  };
-  const getMap = () => {
-    return itemsRef.current;
-  };
   useEffect(() => {
     axiosInstance
       .get(`/api/personal`)
       .then((data) => {
-        setBoards(data.data);
+        setBoard(data.data);
       })
       .catch((error) => {});
   }, []);
 
   const handleClick = () => {
     setIsAdd(true);
-    scrollToId(boardId);
+    scrollToAdd(board.id, itemsRef);
   };
 
   return (
@@ -57,22 +45,12 @@ export default function Home() {
       <StrcatHeader />
       <div
         className={`relative w-full  p-[24px] text-justify ${
-          themeObj[boards.theme].BgColor
+          themeObj[board.theme].BgColor
         } pb-[500px]`}
       >
         <StrcatBoard
-          theme={boards.theme}
-          ref={(node) => {
-            const map = getMap();
-            if (node) {
-              map.set(boards.id, node);
-            } else {
-              map.delete(boards.id);
-            }
-          }}
-          boardId={boards.id}
-          title={boards.title}
-          data={boards.content}
+          board={board}
+          ref={(node) => setMap(node, board, itemsRef)}
           isAdd={isAdd}
           setIsAdd={setIsAdd}
         />

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -62,6 +62,7 @@ export default function Home() {
               onClickHandler={() => router.push('./export')}
               disabled={false}
               color={`bg-white`}
+              bgColor={`${themeObj[board.theme].BgColor}`}
             />
             <BottomButton
               name="공유"
@@ -69,6 +70,7 @@ export default function Home() {
               onClickHandler={() => router.push('./summary')}
               disabled={false}
               color={`bg-strcat-green`}
+              bgColor={`${themeObj[board.theme].BgColor}`}
             />
             <BottomButton
               name="글 작성"
@@ -76,6 +78,7 @@ export default function Home() {
               onClickHandler={handleClick}
               disabled={!observe.boardId}
               color={`bg-strcat-cyan`}
+              bgColor={`${themeObj[board.theme].BgColor}`}
             />
           </div>
         )}

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -68,10 +68,9 @@ export default function Home() {
           title={title}
           data={data}
           isAdd={isAdd}
+          setIsAdd={setIsAdd}
         />
-        {isAdd ? (
-          <Add id={`${params.id}`} setIsAdd={setIsAdd} />
-        ) : (
+        {!isAdd && (
           <div className="sticky bottom-5 w-full">
             <BottomButton
               name="글 작성"

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -9,9 +9,9 @@ import BottomButton from '@/component/BottomButton';
 import ContentPhoto from '@/component/ContentPhoto';
 import { useRecoilState } from 'recoil';
 import { themeState } from '@/recoil/theme';
-import { useParams } from 'next/navigation';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
+import { observeState } from '@/recoil/observe';
 
 export default function Home() {
   const [title, setTitle] = useState<string>('');
@@ -20,7 +20,8 @@ export default function Home() {
   const [isAdd, setIsAdd] = useState<boolean>(false);
   const [theme] = useRecoilState(themeState);
   const itemsRef = useRef(new Map());
-  const params = useParams();
+  const [observe] = useRecoilState(observeState);
+
   const scrollToId = (itemId: number) => {
     const map = getMap();
     const node = map.get(itemId);
@@ -76,7 +77,7 @@ export default function Home() {
               name="글 작성"
               width="w-full"
               onClickHandler={handleClick}
-              disabled={false}
+              disabled={!observe.boardId}
             />
           </div>
         )}

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -8,18 +8,21 @@ import Add from '@/component/Add';
 import BottomButton from '@/component/BottomButton';
 import ContentPhoto from '@/component/ContentPhoto';
 import { useRecoilState } from 'recoil';
-import { themeState } from '@/recoil/theme';
+import { themeObj, themeState } from '@/recoil/theme';
 import Drawer from '@/component/Drawer';
 import StrcatHeader from '@/component/StrcatHeader';
 import { observeState } from '@/recoil/observe';
 import { useRouter } from 'next/navigation';
+import { board } from '@/types/boards';
 
 export default function Home() {
-  const [title, setTitle] = useState<string>('');
-  const [boardId, setBoardId] = useState(0);
-  const [data, setData] = useState<content[] | undefined>(undefined);
+  const [boards, setBoards] = useState<board>({
+    id: 0,
+    title: '',
+    theme: 'strcat',
+    content: [],
+  });
   const [isAdd, setIsAdd] = useState<boolean>(false);
-  const [theme] = useRecoilState(themeState);
   const itemsRef = useRef(new Map());
   const [observe] = useRecoilState(observeState);
   const router = useRouter();
@@ -37,11 +40,8 @@ export default function Home() {
   useEffect(() => {
     axiosInstance
       .get(`/api/personal`)
-      //.get(`/boards/${params.id}/contents`)
       .then((data) => {
-        setBoardId(data.data.id);
-        setTitle(data.data.title);
-        setData(data.data.contents);
+        setBoards(data.data);
       })
       .catch((error) => {});
   }, []);
@@ -56,20 +56,23 @@ export default function Home() {
       <Drawer />
       <StrcatHeader />
       <div
-        className={`relative w-full  p-[24px] text-justify ${theme.BgColor} pb-[500px]`}
+        className={`relative w-full  p-[24px] text-justify ${
+          themeObj[boards.theme].BgColor
+        } pb-[500px]`}
       >
         <StrcatBoard
+          theme={boards.theme}
           ref={(node) => {
             const map = getMap();
             if (node) {
-              map.set(boardId, node);
+              map.set(boards.id, node);
             } else {
-              map.delete(boardId);
+              map.delete(boards.id);
             }
           }}
-          boardId={boardId}
-          title={title}
-          data={data}
+          boardId={boards.id}
+          title={boards.title}
+          data={boards.content}
           isAdd={isAdd}
           setIsAdd={setIsAdd}
         />
@@ -87,14 +90,14 @@ export default function Home() {
               width="basis-1/5"
               onClickHandler={() => router.push('./summary')}
               disabled={false}
-              color={`bg-[#7CED43]`}
+              color={`bg-strcat-green`}
             />
             <BottomButton
               name="글 작성"
               width="basis-3/5"
               onClickHandler={handleClick}
               disabled={!observe.boardId}
-              color={`bg-[#6CD8ED]`}
+              color={`bg-strcat-cyan`}
             />
           </div>
         )}

--- a/src/component/Add.tsx
+++ b/src/component/Add.tsx
@@ -123,6 +123,7 @@ export default function Add({ id, setIsAdd }: AddProps) {
       </div>
       <div className=" bottom-5 flex w-full flex-row">
         <BottomButton
+          color="bg-white"
           name="취소"
           width="basis-1/5"
           onClickHandler={() => setIsAdd(false)}
@@ -153,6 +154,7 @@ export default function Add({ id, setIsAdd }: AddProps) {
           )}
         </form>
         <BottomButton
+          color={`bg-strcat-cyan`}
           name="완료"
           width="basis-3/5"
           onClickHandler={handleClick}

--- a/src/component/Add.tsx
+++ b/src/component/Add.tsx
@@ -42,7 +42,7 @@ export default function Add({ id, setIsAdd }: AddProps) {
       };
 
       axiosInstance
-        .post(`/board/${id}/content`, data)
+        .post(`/boards/${id}/contents`, data)
         .then((res) => {
           console.log(res);
         })

--- a/src/component/Add.tsx
+++ b/src/component/Add.tsx
@@ -42,7 +42,7 @@ export default function Add({ id, setIsAdd }: AddProps) {
       };
 
       axiosInstance
-        .post(`/boards/${id}/contents`, data)
+        .post(`/board/${id}/content`, data)
         .then((res) => {
           console.log(res);
         })
@@ -121,7 +121,7 @@ export default function Add({ id, setIsAdd }: AddProps) {
           </div>
         </div>
       </div>
-      <div className="sticky bottom-5 flex w-full flex-row">
+      <div className=" bottom-5 flex w-full flex-row">
         <BottomButton
           name="취소"
           width="basis-1/5"

--- a/src/component/BottomButton.tsx
+++ b/src/component/BottomButton.tsx
@@ -1,8 +1,12 @@
+import { themeState } from '@/recoil/theme';
+import { useRecoilState } from 'recoil';
+
 interface BottomButtonProps {
   name: string;
   width: string;
   onClickHandler: () => void;
   disabled: boolean;
+  color: string;
 }
 
 export default function BottomButton({
@@ -10,13 +14,21 @@ export default function BottomButton({
   width,
   onClickHandler,
   disabled,
+  color,
 }: BottomButtonProps) {
+  const [theme] = useRecoilState(themeState);
   return (
     <button
       disabled={disabled}
-      className={`${width} mx-2 h-12 rounded-lg bg-black text-xl text-white disabled:bg-[#CCCCCC]`}
+      className={`${width} relative mx-2 h-12 ${color} text-xl disabled:bg-[#CCCCCC]`}
       onClick={onClickHandler}
     >
+      <div
+        className={`absolute left-0 top-0 h-[4.5px] w-[2px] ${theme.BgColor}`}
+      ></div>
+      <div
+        className={`absolute bottom-0 right-0 h-[4.5px] w-[2px] ${theme.BgColor}`}
+      ></div>
       {name}
     </button>
   );

--- a/src/component/BottomButton.tsx
+++ b/src/component/BottomButton.tsx
@@ -1,14 +1,9 @@
-import { themeState } from '@/recoil/theme';
-import { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
-
 interface BottomButtonProps {
   name: string;
   width: string;
   onClickHandler: () => void;
   disabled: boolean;
   color: string;
-  bgColor: string;
 }
 
 export default function BottomButton({

--- a/src/component/BottomButton.tsx
+++ b/src/component/BottomButton.tsx
@@ -1,4 +1,5 @@
 import { themeState } from '@/recoil/theme';
+import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 interface BottomButtonProps {
@@ -7,6 +8,7 @@ interface BottomButtonProps {
   onClickHandler: () => void;
   disabled: boolean;
   color: string;
+  bgColor: string;
 }
 
 export default function BottomButton({
@@ -16,20 +18,20 @@ export default function BottomButton({
   disabled,
   color,
 }: BottomButtonProps) {
-  const [theme] = useRecoilState(themeState);
   return (
     <button
       disabled={disabled}
-      className={`${width} relative mx-2 h-12 ${color} text-xl disabled:bg-[#CCCCCC]`}
+      className={`${width} relative mx-2 h-12 items-center ${color} text-xl disabled:bg-[#CCCCCC]`}
       onClick={onClickHandler}
     >
       <div
-        className={`absolute left-0 top-0 h-[4.5px] w-[2px] ${theme.BgColor}`}
-      ></div>
-      <div
-        className={`absolute bottom-0 right-0 h-[4.5px] w-[2px] ${theme.BgColor}`}
-      ></div>
-      {name}
+        className={`${width} relative bottom-[4.5px] left-[2px] h-12 text-xl ${
+          disabled ? 'bg-[#CCCCCC]' : color
+        }`}
+        style={{ lineHeight: '3rem' }}
+      >
+        <h1 className=" bottom-[-4.5px] left-[-2px]">{name}</h1>
+      </div>
     </button>
   );
 }

--- a/src/component/ContentPhoto.tsx
+++ b/src/component/ContentPhoto.tsx
@@ -8,7 +8,7 @@ export default function ContentPhoto() {
   const [openModal] = useModal();
   const [observe] = useRecoilState(observeState);
   return (
-    <div className="fixed top-[100px] h-[100px] max-w-[312px]">
+    <div className="fixed top-[100px] mx-[24px] h-[100px] max-w-[312px]">
       {observe.photoUrl && observe.photoUrl.length !== 0 && (
         <img
           src={observe.photoUrl}

--- a/src/component/ObserveContent.tsx
+++ b/src/component/ObserveContent.tsx
@@ -1,5 +1,5 @@
 import { content } from '@/types/content';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import { observeState } from '@/recoil/observe';
 import React from 'react';

--- a/src/component/ObserveContent.tsx
+++ b/src/component/ObserveContent.tsx
@@ -3,17 +3,17 @@ import { useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { observeState } from '@/recoil/observe';
 import React from 'react';
-import { themeState } from '@/recoil/theme';
+import { themeObj } from '@/recoil/theme';
 interface props {
   content: content;
   boardId: number;
   isAdd: boolean;
+  theme: 'strcat' | 'calm' | 'green' | 'cyan';
 }
 
-const ObserveContent = ({ content, boardId, isAdd }: props) => {
+const ObserveContent = ({ content, boardId, isAdd, theme }: props) => {
   const ref = useRef<HTMLHeadingElement | null>(null);
   const [observe, setObserve] = useRecoilState(observeState);
-  const [theme] = useRecoilState(themeState);
   useEffect(() => {
     let ratio = 0.01;
     const observer = new IntersectionObserver(
@@ -52,8 +52,8 @@ const ObserveContent = ({ content, boardId, isAdd }: props) => {
         !isAdd &&
         observe.boardId === boardId &&
         observe.contentId === content.id
-          ? `${theme.FontColor1} ' duration-500' inline  w-full  text-[22px] opacity-100 transition-all`
-          : `${theme.DefaultFontColor} ' duration-500'  inline  w-full text-[22px] opacity-30 transition-all`
+          ? `${themeObj[theme].FontColor1} ' duration-500' inline  w-full  text-[22px] opacity-100 transition-all`
+          : `${themeObj[theme].DefaultFontColor} ' duration-500'  inline  w-full text-[22px] opacity-30 transition-all`
       }
     `}
       >
@@ -63,7 +63,7 @@ const ObserveContent = ({ content, boardId, isAdd }: props) => {
         observe.boardId === boardId &&
         observe.contentId === content.id && (
           <div
-            className={`bg-strcat-green absolute right-[24px] mt-[1px]  animate-slide px-1 text-white`}
+            className={`bg-strcat-green absolute right-[24px] z-10 mt-[1px] animate-slide  px-1 text-white opacity-100`}
           >{`From: ${observe.writer}`}</div>
         )}
     </div>

--- a/src/component/ObserveContent.tsx
+++ b/src/component/ObserveContent.tsx
@@ -20,7 +20,7 @@ const ObserveContent = ({ content, boardId, isAdd }: props) => {
       (entries) => {
         entries.forEach(({ isIntersecting, boundingClientRect }) => {
           ratio = 10 / boundingClientRect.height;
-          if (isIntersecting) {
+          if (!isAdd && isIntersecting) {
             setObserve(() => ({
               boardId: boardId,
               contentId: content.id,
@@ -41,7 +41,7 @@ const ObserveContent = ({ content, boardId, isAdd }: props) => {
     return () => {
       observer.disconnect();
     };
-  }, [boardId, content.id, content.photo, content.writer, setObserve]);
+  }, [boardId, content.id, content.photo, content.writer, setObserve, isAdd]);
 
   return (
     <div className="inline">

--- a/src/component/ObserveTitle.tsx
+++ b/src/component/ObserveTitle.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+import { useRecoilState } from 'recoil';
+import { observeState } from '@/recoil/observe';
+import React from 'react';
+interface Props {
+  title: string;
+}
+
+const ObserveContent = ({ title }: Props) => {
+  const ref = useRef<HTMLHeadingElement | null>(null);
+  const [, setObserve] = useRecoilState(observeState);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach(({ isIntersecting }) => {
+          if (isIntersecting) {
+            setObserve((prev) => ({ ...prev, photoUrl: '' }));
+          }
+        });
+      },
+      {
+        rootMargin: '-30% 0% -65% 0%',
+        threshold: 0.1,
+      },
+    );
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, [setObserve]);
+
+  return (
+    <div className="h-[200px]" ref={ref}>
+      <h1 className={` text-[28px] `}>{title}</h1>
+    </div>
+  );
+};
+
+export default React.memo(ObserveContent);

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -7,6 +7,7 @@ import { themeObj } from '@/recoil/theme';
 import Add from './Add';
 import { observeState } from '@/recoil/observe';
 import { board } from '@/types/boards';
+import ObserveTitle from './ObserveTitle';
 
 interface Props {
   board: board;
@@ -25,13 +26,14 @@ const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
       ref={ref}
       className={` font-FiraCode ${themeObj[board.theme].BgColor} px-[24px]`}
     >
-      <div className="h-[200px]">
+      <ObserveTitle title={board.title} />
+      {/* <div className="h-[200px]">
         <h1
           className={` text-[28px] ${themeObj[board.theme].DefaultFontColor}`}
         >
           {board.title}
         </h1>
-      </div>
+      </div> */}
       <div className={`z-0 inline`}>
         {board.content &&
           board.content.map((content: content) => {

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -6,18 +6,16 @@ import { useRecoilState } from 'recoil';
 import { themeObj } from '@/recoil/theme';
 import Add from './Add';
 import { observeState } from '@/recoil/observe';
+import { board } from '@/types/boards';
 
 interface Props {
-  title: string;
-  data: content[] | undefined;
-  boardId: number;
+  board: board;
   isAdd: boolean;
   setIsAdd: Dispatch<SetStateAction<boolean>>;
-  theme: 'strcat' | 'calm' | 'green' | 'cyan';
 }
 
 const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
-  { title, data, boardId, isAdd, setIsAdd, theme },
+  { board, isAdd, setIsAdd },
   ref,
 ) {
   const [observe] = useRecoilState(observeState);
@@ -25,28 +23,30 @@ const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
   return (
     <div
       ref={ref}
-      className={` font-FiraCode ${themeObj[theme].BgColor} px-[24px]`}
+      className={` font-FiraCode ${themeObj[board.theme].BgColor} px-[24px]`}
     >
       <div className="h-[200px]">
-        <h1 className={` text-[28px] ${themeObj[theme].DefaultFontColor}`}>
-          {title}
+        <h1
+          className={` text-[28px] ${themeObj[board.theme].DefaultFontColor}`}
+        >
+          {board.title}
         </h1>
       </div>
       <div className={`z-0 inline`}>
-        {data &&
-          data.map((content: content) => {
+        {board.content &&
+          board.content.map((content: content) => {
             return (
               <ObserveContent
                 isAdd={isAdd}
                 key={content.id}
                 content={content}
-                boardId={boardId}
-                theme={theme}
+                boardId={board.id}
+                theme={board.theme}
               />
             );
           })}
       </div>
-      {isAdd && boardId === observe.boardId && (
+      {isAdd && board.id === observe.boardId && (
         <Add id={`${observe.boardId}`} setIsAdd={setIsAdd} />
       )}
       {!isAdd && <div className=" h-12"></div>}

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -1,9 +1,9 @@
 import { content } from '@/types/content';
 import ObserveContent from './ObserveContent';
-import { forwardRef, Dispatch, SetStateAction } from 'react';
+import { forwardRef, Dispatch, SetStateAction, useState } from 'react';
 import React from 'react';
 import { useRecoilState } from 'recoil';
-import { themeState } from '@/recoil/theme';
+import { themeObj } from '@/recoil/theme';
 import Add from './Add';
 import { observeState } from '@/recoil/observe';
 
@@ -13,18 +13,24 @@ interface Props {
   boardId: number;
   isAdd: boolean;
   setIsAdd: Dispatch<SetStateAction<boolean>>;
+  theme: 'strcat' | 'calm' | 'green' | 'cyan';
 }
 
 const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
-  { title, data, boardId, isAdd, setIsAdd },
+  { title, data, boardId, isAdd, setIsAdd, theme },
   ref,
 ) {
-  const [theme] = useRecoilState(themeState);
   const [observe] = useRecoilState(observeState);
+
   return (
-    <div ref={ref} className={`inline font-FiraCode`}>
+    <div
+      ref={ref}
+      className={` font-FiraCode ${themeObj[theme].BgColor} px-[24px]`}
+    >
       <div className="h-[200px]">
-        <h1 className={` text-[28px] ${theme.DefaultFontColor} `}>{title}</h1>
+        <h1 className={` text-[28px] ${themeObj[theme].DefaultFontColor}`}>
+          {title}
+        </h1>
       </div>
       <div className={`z-0 inline`}>
         {data &&
@@ -35,6 +41,7 @@ const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
                 key={content.id}
                 content={content}
                 boardId={boardId}
+                theme={theme}
               />
             );
           })}

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -27,13 +27,6 @@ const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
       className={` font-FiraCode ${themeObj[board.theme].BgColor} px-[24px]`}
     >
       <ObserveTitle title={board.title} />
-      {/* <div className="h-[200px]">
-        <h1
-          className={` text-[28px] ${themeObj[board.theme].DefaultFontColor}`}
-        >
-          {board.title}
-        </h1>
-      </div> */}
       <div className={`z-0 inline`}>
         {board.content &&
           board.content.map((content: content) => {

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -1,22 +1,26 @@
 import { content } from '@/types/content';
 import ObserveContent from './ObserveContent';
-import { forwardRef } from 'react';
+import { forwardRef, Dispatch, SetStateAction } from 'react';
 import React from 'react';
 import { useRecoilState } from 'recoil';
 import { themeState } from '@/recoil/theme';
+import Add from './Add';
+import { observeState } from '@/recoil/observe';
 
-interface props {
+interface Props {
   title: string;
   data: content[] | undefined;
   boardId: number;
   isAdd: boolean;
+  setIsAdd: Dispatch<SetStateAction<boolean>>;
 }
 
-const StrcatBoard = forwardRef<HTMLDivElement, props>(function StrcatBoard(
-  { title, data, boardId, isAdd },
+const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
+  { title, data, boardId, isAdd, setIsAdd },
   ref,
 ) {
   const [theme] = useRecoilState(themeState);
+  const [observe] = useRecoilState(observeState);
   return (
     <div ref={ref} className={`inline font-FiraCode`}>
       <div className="h-[200px]">
@@ -35,6 +39,9 @@ const StrcatBoard = forwardRef<HTMLDivElement, props>(function StrcatBoard(
             );
           })}
       </div>
+      {isAdd && boardId === observe.boardId && (
+        <Add id={`${observe.boardId}`} setIsAdd={setIsAdd} />
+      )}
       {!isAdd && <div className=" h-12"></div>}
     </div>
   );

--- a/src/component/StrcatGroupTitle.tsx
+++ b/src/component/StrcatGroupTitle.tsx
@@ -10,13 +10,11 @@ export default function StrcatGroupTitle({ board, scrollToId }: Props) {
   return (
     <div
       key={board.id}
-      className={`my-[32px] ${themeObj[board.theme].BgColor}`}
+      className={`my-[32px] ${themeObj[board.theme].background}`}
       onClick={() => scrollToId(board.id)}
     >
       <p
-        className={`cursor-pointer text-xl ${
-          themeObj[board.theme].DefaultFontColor
-        }`}
+        className={`cursor-pointer text-xl ${themeObj[board.theme].background}`}
       >
         {board.title}
       </p>

--- a/src/component/StrcatGroupTitle.tsx
+++ b/src/component/StrcatGroupTitle.tsx
@@ -1,0 +1,25 @@
+import { themeObj } from '@/recoil/theme';
+import { board } from '@/types/boards';
+
+interface Props {
+  board: board;
+  scrollToId: (arg0: number) => void;
+}
+
+export default function StrcatGroupTitle({ board, scrollToId }: Props) {
+  return (
+    <div
+      key={board.id}
+      className={`my-[32px] ${themeObj[board.theme].BgColor}`}
+      onClick={() => scrollToId(board.id)}
+    >
+      <p
+        className={`cursor-pointer text-xl ${
+          themeObj[board.theme].DefaultFontColor
+        }`}
+      >
+        {board.title}
+      </p>
+    </div>
+  );
+}

--- a/src/recoil/theme.ts
+++ b/src/recoil/theme.ts
@@ -37,6 +37,13 @@ export const cyan: themeState = {
   BgColor: 'bg-strcat-black',
 };
 
+export const themeObj = {
+  strcat: strcat,
+  calm: calm,
+  green: green,
+  cyan: cyan,
+};
+
 export const themeState = atom<themeState>({
   key: 'themeState',
   default: strcat,

--- a/src/types/boards.ts
+++ b/src/types/boards.ts
@@ -3,6 +3,6 @@ import { content } from './content';
 export interface board {
   id: number;
   title: string;
-  backgroundColor: string;
+  theme: 'strcat' | 'calm' | 'green' | 'cyan';
   content: content[];
 }

--- a/src/utils/scrollTo.ts
+++ b/src/utils/scrollTo.ts
@@ -1,0 +1,26 @@
+import { MutableRefObject } from 'react';
+import { board } from '@/types/boards';
+
+export const scrollToAdd = (
+  itemId: number,
+  itemsRef: MutableRefObject<Map<any, any>>,
+) => {
+  const map = itemsRef.current;
+  const node = map.get(itemId);
+  const height = node.offsetHeight;
+  const offset = node.offsetTop + height - 500; // 하단의 여백을 500만큼 줬으므로 그만큼 빼준다.
+  window.scrollTo({ top: offset, behavior: 'smooth' });
+};
+
+export const setMap = (
+  node: HTMLDivElement | null,
+  board: board,
+  itemsRef: MutableRefObject<Map<any, any>>,
+) => {
+  const map = itemsRef.current;
+  if (node) {
+    map.set(board.id, node);
+  } else {
+    map.delete(board.id);
+  }
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'strcat-green': '#7CED43',
         'strcat-blue': '#557FE4',
         'strcat-yellow': '#FBFF36',
+        'strcat-cyan': '#6CD8ED',
         'strcat-buttonColor': '#8F38FF',
       },
       keyframes: {


### PR DESCRIPTION
# Describe your changes
- grouppage와 personalpage에서 중복으로 사용하는 함수를 utils로 뺐습니다.
- bottombutton에 스타일이 적용되었습니다.
- group, personal페이지에 버튼이 적용되었습니다. (생성자를 기준으로 적용하였으며 생성자가 아닌 경우에 대한 분기는 추후 적용예정입니다.
- gruoppage에서 글작성 버튼을 누르면 현재 보고 있는 strcat에 대해 글작성 컴포넌트가 뜨고, 해당 위치로 스크롤됩니다.
- 현재 grouppge에서 해당 strcat의 위치에 대한 테마가 각각 적용되어있는 상태인데 현재 observe된 strcat의 theme에 따라 전체 테마가 바뀌도록 변경할 예정입니다.
- @lamPolar bottombutton을 변경하면서 add컴포넌트를 변경한 부분이 있습니다. color를 임의로 추가했고, 그룹페이지에서 add 컴포넌트를 고정해야해서 sticky를 뺐습니다. 
- @Arkingco 역시 export페이지에서 color를 임의로 추가했습니다.
## Screen Capture
<img width="483" alt="스크린샷 2023-11-25 오후 3 20 15" src="https://github.com/RollingPaper42/Front-End/assets/114637463/6bbe2c32-277d-4996-b633-130b93dfcd75">
<img width="487" alt="스크린샷 2023-11-25 오후 3 20 33" src="https://github.com/RollingPaper42/Front-End/assets/114637463/68a165a3-a521-4d81-9363-7ee7b346bbcc">

# Issue number and link
- #19 
