### PR TITLE
[Fix]strcatHeader useEffect 의존성 영역에 들어간 checkLogin 함수 제거

### DIFF
--- a/src/component/StrcatHeader.tsx
+++ b/src/component/StrcatHeader.tsx
@@ -16,7 +16,7 @@ export default function StrcatHeader() {
 
   useEffect(() => {
     checkLogin();
-  }, [checkLogin]);
+  }, []);
 
   return (
     <div className="fixed top-0 z-10 w-full max-w-md">


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Pull-Request 생성 전 체크리스트(꼭 한번 읽어주세요!!)
  1. 이슈 이름은 다른 사람도 이해할 수 있나요?
  2. 리뷰가 필요한 사람(Reviewers)을 추가했나요?
  3. 이슈 책임자(Assignees)를 추가했나요?
  4. 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
    - [Feat]
    - [Docs]
    - [Chore]
    - [Refactor]
    - [Fix]
  5. Labels에는 해당 이슈의 성향을 잘 나타내나요?
  6. npm run build 명령을 모든 커밋 이후에 실행했나요?
 -->
# Describe your changes
- strcatHeader useEffect 의존성 영역에 들어간 checkLogin 함수 제거 하여 login check api 호출을 막음
## Screen Capture
<img width="1197" alt="스크린샷 2023-11-27 오후 5 03 18" src="https://github.com/RollingPaper42/Front-End/assets/28525747/91fe4f2d-42cf-4590-8eed-043cb46fedcc">

# Issue number and link
- #109 
