### PR TITLE
feat/page height 조절 및 backbutton router 수정 및 그룹 페이지 수정#108

### DIFF
--- a/src/app/create/group/page.tsx
+++ b/src/app/create/group/page.tsx
@@ -72,7 +72,7 @@ export default function Create() {
           <div
             className={`h-full text-center text-[18px] ${Theme.defaultText} flex basis-4/6 items-center justify-center`}
           >
-            스트링캣 만들기
+            그룹 스트링캣 만들기
           </div>
         </div>
         <div className="basis-1/6">

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -55,7 +55,10 @@ export default function Create() {
 
   const handleChangeTitle = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const TextAreaTitle = e.currentTarget.value;
+    const textarea: HTMLTextAreaElement = e.target;
     const byteLength = new TextEncoder().encode(TextAreaTitle).length;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
 
     if (byteLength <= 90) {
       handleTitle(e);
@@ -89,6 +92,7 @@ export default function Create() {
                 height={24}
                 alt="backpagebutton"
                 className="ml-[24px] mt-[16px]"
+                onClick={() => router.push(`/`)}
               />
             </div>
             <div className=" basis-4/6">
@@ -106,9 +110,9 @@ export default function Create() {
             <div className="w-80">
               <textarea
                 id="titleMessage"
-                rows={3}
+                rows={1}
                 value={title}
-                className={` w-full ${Theme.background} text-[22px] ${Theme.defaultText} outline-none placeholder:${Theme.defaultText}`}
+                className={` w-full resize-none ${Theme.background} text-[22px] ${Theme.defaultText} outline-none placeholder:${Theme.defaultText}`}
                 placeholder="제목을 입력해주세요."
                 maxLength={30}
                 onChange={(e) => handleChangeTitle(e)}
@@ -120,11 +124,11 @@ export default function Create() {
             </div>
           </div>
         </div>
-        <div className="mx-[24px] basis-5/12">
+        <div className="mx-[24px] mt-[24px] basis-5/12">
           <div className={`inline text-[18px] ${Theme.highlightText}`}>
             스트링캣을 생성하면 이곳에 문자열을 이을 수 있어요.
           </div>
-          <div className={`inline text-[18px] ${Theme.defaultText}`}>
+          <div className={`inline text-[18px] opacity-30 ${Theme.defaultText}`}>
             스트링캣을 생성하면 이곳에 문자열을 이을 수 있어요.
           </div>
         </div>

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -3,6 +3,7 @@
 import { themeState } from '@/recoil/theme';
 import Image from 'next/image';
 import { useRecoilState } from 'recoil';
+
 import { axiosInstance } from '@/utils/axios';
 import { useEffect, useState } from 'react';
 import BottomButton from '@/component/BottomButton';


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Pull-Request 생성 전 체크리스트(꼭 한번 읽어주세요!!)
  1. 이슈 이름은 다른 사람도 이해할 수 있나요?
  2. 리뷰가 필요한 사람(Reviewers)을 추가했나요?
  3. 이슈 책임자(Assignees)를 추가했나요?
  4. 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
    - [Feat]
    - [Docs]
    - [Chore]
    - [Refactor]
    - [Fix]
  5. Labels에는 해당 이슈의 성향을 잘 나타내나요?
  6. npm run build 명령을 모든 커밋 이후에 실행했나요?
 -->
# Describe your changes
1. backbutton 클릭 시  onclick을 활용하여 main 페이지로 이동하도록 변경하였습니다.
2. 
    textarea.style.height = 'auto';
    textarea.style.height = `${textarea.scrollHeight}px`;
    상단의 코드를 사용하여 style.height를 auto로 받고 scrollHeight대로 height를 수정하여 textarea의 글자 줄 수 대로 높이를 변경하였습니다.
3. 그룹 create 페이지 "스트링캣 만들기" -> "그룹 스트링캣 만들기"로 수정
    
## Screen Capture

# Issue number and link
- #108 
