### PR TITLE
[Fix] boardId string으로 타입변경, data값 없을때 personal페이지 안보이는 에러 수정

### DIFF
--- a/src/app/group/[id]/page.tsx
+++ b/src/app/group/[id]/page.tsx
@@ -25,7 +25,7 @@ export default function Group({ params }: { params: { id: string } }) {
   const [observe] = useRecoilState(observeState);
   const [isOwner, setIsOwner] = useState<boolean>(false);
   const router = useRouter();
-  const scrollToId = (itemId: number) => {
+  const scrollToId = (itemId: string) => {
     const map = itemsRef.current;
     const node = map.get(itemId);
     const offset = node.offsetTop;
@@ -48,7 +48,7 @@ export default function Group({ params }: { params: { id: string } }) {
         setIsOwner(data.data.isOwner);
       })
       .catch((error) => {});
-  }, []);
+  }, [params.id]);
   return (
     <>
       <Drawer />

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -39,7 +39,7 @@ export default function Personal({ params }: { params: { id: string } }) {
     setIsAdd(true);
     scrollToAdd(board[0].id, itemsRef);
   };
-  if (!board.length) return null;
+  // if (!board.length) return null;
   return (
     <>
       <Drawer />

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'next/navigation';
 import { board } from '@/types/boards';
 import { scrollToAdd, setMap } from '@/utils/scrollTo';
 import { handleShare } from '@/utils/handleShare';
+import ShareButton from '@/component/ShareButton';
 
 export default function Personal({ params }: { params: { id: string } }) {
   const [board, setBoard] = useState<board[]>([]);
@@ -33,13 +34,12 @@ export default function Personal({ params }: { params: { id: string } }) {
         setIsOwner(data.data.isOwner);
       })
       .catch((error) => {});
-  }, []);
+  }, [params.id]);
 
   const handleClick = () => {
     setIsAdd(true);
     scrollToAdd(board[0].id, itemsRef);
   };
-  // if (!board.length) return null;
   return (
     <>
       <Drawer />
@@ -47,12 +47,14 @@ export default function Personal({ params }: { params: { id: string } }) {
       <div
         className={`relative w-full  py-[24px] text-justify ${theme.background} pb-[500px]`}
       >
-        <StrcatBoard
-          board={board[0]}
-          ref={(node) => setMap(node, board[0], itemsRef)}
-          isAdd={isAdd}
-          setIsAdd={setIsAdd}
-        />
+        {board.length && (
+          <StrcatBoard
+            board={board[0]}
+            ref={(node) => setMap(node, board[0], itemsRef)}
+            isAdd={isAdd}
+            setIsAdd={setIsAdd}
+          />
+        )}
         {!isAdd &&
           (isOwner ? (
             <div className="fixed bottom-5 left-0 z-50 flex w-full items-center justify-center">
@@ -107,13 +109,8 @@ export default function Personal({ params }: { params: { id: string } }) {
               </div>
             </>
           ))}
-        {!board[0].contents.length && !isAdd && (
-          <div
-            className="  h-32 w-32 bg-slate-200"
-            onClick={() => handleShare(`/personal/${params.id}`)}
-          >
-            공유하기
-          </div>
+        {board.length && !board[0].contents.length && !isAdd && (
+          <ShareButton params={params.id} />
         )}
         {!isAdd && <ContentPhoto />}
       </div>

--- a/src/component/ObserveContent.tsx
+++ b/src/component/ObserveContent.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { themeObj, themeState } from '@/recoil/theme';
 interface props {
   content: content;
-  boardId: number;
+  boardId: string;
   isAdd: boolean;
   boardTheme: 'strcat' | 'calm' | 'green' | 'cyan';
 }

--- a/src/component/ShareButton.tsx
+++ b/src/component/ShareButton.tsx
@@ -1,0 +1,16 @@
+import { handleShare } from '@/utils/handleShare';
+
+interface Props {
+  params: string;
+}
+
+export default function ShareButton({ params }: Props) {
+  return (
+    <div
+      className="  h-32 w-32 bg-slate-200"
+      onClick={() => handleShare(`/personal/${params}`)}
+    >
+      공유하기
+    </div>
+  );
+}

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -26,9 +26,8 @@ const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
   { board, isAdd, setIsAdd },
   ref,
 ) {
-  if (!board) return null;
   const [observe] = useRecoilState(observeState);
-  const [theme, setTheme] = useRecoilState(themeState);
+  const [theme] = useRecoilState(themeState);
   const [content, setContent] = useState<content[]>([]);
   useEffect(() => {
     setContent(board.contents);

--- a/src/component/StrcatBoard.tsx
+++ b/src/component/StrcatBoard.tsx
@@ -26,9 +26,10 @@ const StrcatBoard = forwardRef<HTMLDivElement, Props>(function StrcatBoard(
   { board, isAdd, setIsAdd },
   ref,
 ) {
+  if (!board) return null;
   const [observe] = useRecoilState(observeState);
   const [theme, setTheme] = useRecoilState(themeState);
-  const [content, setContent] = useState(board.contents);
+  const [content, setContent] = useState<content[]>([]);
   useEffect(() => {
     setContent(board.contents);
   }, [board]);

--- a/src/component/StrcatGroupTitle.tsx
+++ b/src/component/StrcatGroupTitle.tsx
@@ -4,7 +4,7 @@ import Strcat from './Icon/Strcat';
 
 interface Props {
   board: board;
-  scrollToId: (arg0: number) => void;
+  scrollToId: (arg0: string) => void;
 }
 
 export default function StrcatGroupTitle({ board, scrollToId }: Props) {

--- a/src/recoil/observe.ts
+++ b/src/recoil/observe.ts
@@ -3,7 +3,7 @@ import { atom } from 'recoil';
 export const observeState = atom({
   key: 'observeState',
   default: {
-    boardId: 0,
+    boardId: '',
     contentId: 0,
     photoUrl: '',
     writer: '',

--- a/src/types/boards.ts
+++ b/src/types/boards.ts
@@ -1,7 +1,7 @@
 import { content } from './content';
 
 export interface board {
-  id: number;
+  id: string;
   title: string;
   theme: 'strcat' | 'calm' | 'green' | 'cyan';
   contents: content[];

--- a/src/utils/scrollTo.ts
+++ b/src/utils/scrollTo.ts
@@ -2,7 +2,7 @@ import { MutableRefObject } from 'react';
 import { board } from '@/types/boards';
 
 export const scrollToAdd = (
-  itemId: number,
+  itemId: string,
   itemsRef: MutableRefObject<Map<any, any>>,
 ) => {
   const map = itemsRef.current;


### PR DESCRIPTION

# Describe your changes
- data값이 없을때 personal페이지가 보이지 않는 부분을 수정하였습니다.
- 백엔드에서 boardId를 암호화된 string으로 받기로 함에 따라서 boardId타입을 string으로 수정하였습니다.
## Screen Capture
<img width="411" alt="스크린샷 2023-11-28 오후 5 09 52" src="https://github.com/RollingPaper42/Front-End/assets/114637463/7a59762f-1fee-40e3-acef-e492e2a9d026">

# Issue number and link
- #12 
