### PR TITLE
[Style] summary 페이지 테마 적용 

### DIFF
--- a/src/app/group/[id]/summary/page.tsx
+++ b/src/app/group/[id]/summary/page.tsx
@@ -12,25 +12,24 @@ import { handleShare } from '@/utils/handleShare';
 
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
-  const [Theme] = useRecoilState(themeState);
-  const [Title, setTitle] = useState(
-    '테스트입니다테스트입니다테스트입니다테스트입니다테스트입니다',
-  );
-  const [ContentCount, setContentCount] = useState(13);
-  const [ContentTextCount, setContentTextCount] = useState(1305);
-  const [boardCount, setboardCount] = useState(13);
+  const [theme, setTheme] = useRecoilState(themeState);
+  const [title, setTitle] = useState('');
+  const [contentCount, setContentCount] = useState(0);
+  const [contentTextCount, setContentTextCount] = useState(0);
+  const [boardCount, setboardCount] = useState(0);
 
   useEffect(() => {
+    setTheme(themeObj['strcat']);
     axiosInstance
       .get(`/board-groups/${params.id}/summaries`)
-      .then((data) => {
-        setTitle(data.data.title);
-        setContentCount(data.data.contentCount);
-        setContentTextCount(data.data.contentTextCount);
-        setboardCount(data.data.boardCount);
+      .then((res) => {
+        setTitle(res.data.title);
+        setContentCount(res.data.contentCount);
+        setContentTextCount(res.data.contentTextCount);
+        setboardCount(res.data.boardCount);
       })
       .catch((err) => {
-        if (err.response.status === 406) {
+        if (err.response?.status === 406) {
           alert('올바르지 않은 입력입니다. 다시 작성해주세요.');
         }
       });
@@ -41,75 +40,61 @@ export default function Summary({ params }: { params: { id: string } }) {
   }
 
   return (
-    <div className={`${Theme.background}`}>
+    <div className={`${theme.background}`}>
       <div className=" fixed flex h-full w-full max-w-md flex-col">
-        <div className=" basis-3/12">
-          <div className="flex h-full w-full flex-col">
-            <div className=" basis-2/5">
-              <div className=" flex h-full w-full flex-row">
-                <div
-                  className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
-                  onClick={() => router.push(`/group/${params.id}`)}
-                >
-                  <Back color={Theme.backIcon} />
-                </div>
-                <div className=" basis-4/6">
-                  <div
-                    className={`text-center text-[18px] ${Theme.defaultText} mt-[16px]`}
-                  >
-                    그룹 스트링캣 공유하기
-                  </div>
-                </div>
-                <div className=" basis-1/6"></div>
+        <div className="flex h-full basis-3/12 flex-col">
+          <div className="flex h-full w-full basis-2/5 flex-row">
+            <div
+              className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
+              onClick={() => router.push(`/group/${params.id}`)}
+            >
+              <Back color={theme.backIcon} />
+            </div>
+            <div className=" basis-4/6">
+              <div
+                className={`text-center text-[18px] ${theme.titleText} mt-[16px]`}
+              >
+                그룹 스트링캣 공유하기
               </div>
             </div>
-            <div className="mx-[25px]  mt-[7px] basis-3/5">
-              <div className={`text-[22px] ${Theme.defaultText}`}>{Title}</div>
-            </div>
+            <div className=" basis-1/6" />
+          </div>
+          <div className="mx-[24px] mt-[40px] basis-3/5">
+            <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
           </div>
         </div>
-        <div className=" basis-7/12 ">
-          <div className=" flex h-full w-full flex-col ">
-            <div className=" basis-1/4"></div>
-            <div className=" basis-1/4">
-              <div className="flex h-full w-full flex-row">
-                <div className="basis-2/3">
-                  <div
-                    className={`${Theme.defaultText} mx-[24px] text-[26px] `}
-                  >
-                    총 {ContentCount}번의 <br /> 마음으로 <br /> {boardCount}
-                    개의 스트링캣이
-                    <br /> 총 {formatNumberWithCommas(ContentTextCount)}자{' '}
-                    <br />
-                    이어졌어요!
-                  </div>
-                </div>
-                <div className="basis-1/3"></div>
-              </div>
+        <div className="flex h-full w-full basis-7/12 flex-col ">
+          <div className="basis-1/4" />
+          <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
+            <div className={`${theme.summaryText} w-full text-[26px] `}>
+              총 {contentCount}번의
+              <br /> 마음으로
+              <br /> {boardCount}개의 스트링캣이
+              <br /> 총 {formatNumberWithCommas(contentTextCount)}자
+              <br /> 이어졌어요!
             </div>
-            <div className=" basis-1/4 "></div>
-            <div className=" basis-1/4"></div>
           </div>
+          <div className="basis-1/4 " />
+          <div className="basis-1/4" />
         </div>
-        <div className=" mx-[25px] basis-2/12">
-          <div className="flex h-full w-full flex-row items-center justify-center">
-            <BottomButton
-              height="h-[42px]"
-              name="공유하기"
-              width="w-[312px]"
-              onClickHandler={() => handleShare(`/group/${params.id}`)}
-              disabled={false}
-              color={`${Theme.rightCTA}`}
-            />
-          </div>
+        <div className="basis-2/12 " />
+        <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
+          <BottomButton
+            height="h-[42px]"
+            name="공유하기"
+            width="w-full"
+            onClickHandler={() => handleShare(`/group/${params.id}`)}
+            disabled={false}
+            color={`${theme.rightCTA}`}
+          />
         </div>
       </div>
       <div className="flex h-full w-full flex-row">
-        <div className="basis-1/2"></div>
+        <div className="basis-1/2" />
         <div className="basis-1/2 pr-[24px] pt-[186px]">
           <LongCat
-            bodyColor={Theme.catTheme.mainCat}
-            eyeColor={Theme.catTheme.mainCatEye}
+            bodyColor={theme.catTheme.mainCat}
+            eyeColor={theme.catTheme.mainCatEye}
           />
         </div>
       </div>

--- a/src/app/group/[id]/summary/page.tsx
+++ b/src/app/group/[id]/summary/page.tsx
@@ -6,10 +6,10 @@ import { axiosInstance } from '@/utils/axios';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { handleShare } from '@/utils/handleShare';
-import Back from '@/component/Icon/Back';
 import LongCat from '@/component/Icon/LongCat';
 import BottomButton from '@/component/BottomButton';
 import SummaryBoard from '@/component/SummaryBoard';
+import BackButtonHeader from '@/component/HeaderLayout/BackButtonHeader';
 
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
@@ -38,60 +38,45 @@ export default function Summary({ params }: { params: { id: string } }) {
 
   return (
     <div className={`${theme.background}`}>
-      <div className=" fixed flex h-full w-full max-w-md flex-col">
-        <div className="flex h-full basis-3/12 flex-col">
-          <div className="flex h-full w-full basis-2/5 flex-row">
-            <div
-              className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
-              onClick={() => router.push(`/group/${params.id}`)}
-            >
-              <Back color={theme.backIcon} />
-            </div>
-            <div className=" basis-4/6">
-              <div
-                className={`text-center text-[18px] ${theme.titleText} mt-[16px]`}
-              >
-                그룹 스트링캣 공유하기
-              </div>
-            </div>
-            <div className=" basis-1/6" />
-          </div>
-          <div className="mx-[24px] mt-[40px] basis-3/5">
+      <BackButtonHeader
+        title="그룹 스트링캣 공유하기"
+        backClickHandler={() => router.back()}
+      />
+      <div className="fixed flex h-full w-full max-w-md flex-col">
+        <div className="reltaive flex h-full w-full flex-col px-[24px]">
+          <div className="mt-24 flex w-full">
             <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
           </div>
-        </div>
-        <div className="flex h-full w-full basis-7/12 flex-col ">
-          <div className="basis-1/4" />
-          <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-            <SummaryBoard
-              contentCount={contentCount}
-              contentTextCount={contentTextCount}
-              boardCount={boardCount}
-              summaryTextColor={theme.summaryText}
-            />
+          <div className="mt-[138px] flex h-full w-full flex-col">
+            <div className="flex h-full w-full basis-1/4 flex-row">
+              <SummaryBoard
+                contentCount={contentCount}
+                contentTextCount={contentTextCount}
+                boardCount={boardCount}
+                summaryTextColor={theme.summaryText}
+              />
+            </div>
           </div>
-          <div className="basis-1/2" />
-        </div>
-        <div className="basis-2/12 " />
-        <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
-          <BottomButton
-            height="h-[42px]"
-            name="공유하기"
-            width="w-full"
-            onClickHandler={() => handleShare(`/group/${params.id}`)}
-            disabled={false}
-            color={`${theme.rightCTA}`}
-          />
         </div>
       </div>
-      <div className="flex h-full w-full flex-row">
+      <div className="flex h-full w-full">
         <div className="basis-1/2" />
-        <div className="basis-1/2 pr-[24px] pt-[186px]">
+        <div className="basis-1/2 pr-[44px] pt-[186px]">
           <LongCat
             bodyColor={theme.catTheme.mainCat}
             eyeColor={theme.catTheme.mainCatEye}
           />
         </div>
+      </div>
+      <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
+        <BottomButton
+          height="h-[42px]"
+          name="공유하기"
+          width="w-full"
+          onClickHandler={() => handleShare(`/personal/${params.id}`)}
+          disabled={false}
+          color={`${theme.rightCTA}`}
+        />
       </div>
     </div>
   );

--- a/src/app/group/[id]/summary/page.tsx
+++ b/src/app/group/[id]/summary/page.tsx
@@ -45,7 +45,7 @@ export default function Summary({ params }: { params: { id: string } }) {
       <div className="fixed flex h-full w-full max-w-md flex-col">
         <div className="reltaive flex h-full w-full flex-col px-[24px]">
           <div className="mt-24 flex w-full">
-            <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
+            <div className={`text-[24px] ${theme.titleText}`}>{title}</div>
           </div>
           <div className="mt-[138px] flex h-full w-full flex-col">
             <div className="flex h-full w-full basis-1/4 flex-row">

--- a/src/app/group/[id]/summary/page.tsx
+++ b/src/app/group/[id]/summary/page.tsx
@@ -31,7 +31,7 @@ export default function Summary({ params }: { params: { id: string } }) {
       })
       .catch((err) => {
         if (err.response?.status === 406) {
-          alert('올바르지 않은 입력입니다. 다시 작성해주세요.');
+          router.push('/not-found');
         }
       });
   }, []);

--- a/src/app/group/[id]/summary/page.tsx
+++ b/src/app/group/[id]/summary/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import Back from '@/component/Icon/Back';
 import LongCat from '@/component/Icon/LongCat';
 import { handleShare } from '@/utils/handleShare';
+import SummaryBoard from '@/component/SummaryBoard';
 
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
@@ -34,10 +35,6 @@ export default function Summary({ params }: { params: { id: string } }) {
         }
       });
   }, []);
-
-  function formatNumberWithCommas(inputText: number) {
-    return inputText.toLocaleString();
-  }
 
   return (
     <div className={`${theme.background}`}>
@@ -66,16 +63,14 @@ export default function Summary({ params }: { params: { id: string } }) {
         <div className="flex h-full w-full basis-7/12 flex-col ">
           <div className="basis-1/4" />
           <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-            <div className={`${theme.summaryText} w-full text-[26px] `}>
-              총 {contentCount}번의
-              <br /> 마음으로
-              <br /> {boardCount}개의 스트링캣이
-              <br /> 총 {formatNumberWithCommas(contentTextCount)}자
-              <br /> 이어졌어요!
-            </div>
+            <SummaryBoard
+              contentCount={contentCount}
+              contentTextCount={contentTextCount}
+              boardCount={boardCount}
+              summaryTextColor={theme.summaryText}
+            />
           </div>
-          <div className="basis-1/4 " />
-          <div className="basis-1/4" />
+          <div className="basis-1/2" />
         </div>
         <div className="basis-2/12 " />
         <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">

--- a/src/app/group/[id]/summary/page.tsx
+++ b/src/app/group/[id]/summary/page.tsx
@@ -4,11 +4,11 @@ import { themeObj, themeState } from '@/recoil/theme';
 import { useRecoilState } from 'recoil';
 import { axiosInstance } from '@/utils/axios';
 import { useEffect, useState } from 'react';
-import BottomButton from '@/component/BottomButton';
 import { useRouter } from 'next/navigation';
+import { handleShare } from '@/utils/handleShare';
 import Back from '@/component/Icon/Back';
 import LongCat from '@/component/Icon/LongCat';
-import { handleShare } from '@/utils/handleShare';
+import BottomButton from '@/component/BottomButton';
 import SummaryBoard from '@/component/SummaryBoard';
 
 export default function Summary({ params }: { params: { id: string } }) {

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import Back from '@/component/Icon/Back';
 import LongCat from '@/component/Icon/LongCat';
 import { handleShare } from '@/utils/handleShare';
+import SummaryBoard from '@/component/SummaryBoard';
 
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
@@ -33,10 +34,6 @@ export default function Summary({ params }: { params: { id: string } }) {
         }
       });
   }, []);
-
-  function formatNumberWithCommas(inputText: number) {
-    return inputText.toLocaleString();
-  }
 
   return (
     <div className={`${theme.background}`}>
@@ -65,16 +62,13 @@ export default function Summary({ params }: { params: { id: string } }) {
         <div className="flex h-full w-full basis-7/12 flex-col ">
           <div className="basis-1/4" />
           <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-            <div className={`${theme.summaryText} w-full text-[26px] `}>
-              총 {contentCount}번의
-              <br /> 마음으로
-              <br /> 내 스트링캣이
-              <br /> 총 {formatNumberWithCommas(contentTextCount)}자
-              <br /> 이어졌어요!
-            </div>
+            <SummaryBoard
+              contentCount={contentCount}
+              contentTextCount={contentTextCount}
+              summaryTextColor={theme.summaryText}
+            />
           </div>
-          <div className="basis-1/4" />
-          <div className="basis-1/4" />
+          <div className="basis-1/2" />
         </div>
         <div className="basis-2/12 " />
         <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -6,10 +6,10 @@ import { axiosInstance } from '@/utils/axios';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { handleShare } from '@/utils/handleShare';
-import Back from '@/component/Icon/Back';
 import LongCat from '@/component/Icon/LongCat';
 import BottomButton from '@/component/BottomButton';
 import SummaryBoard from '@/component/SummaryBoard';
+import BackButtonHeader from '@/component/HeaderLayout/BackButtonHeader';
 
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
@@ -37,40 +37,35 @@ export default function Summary({ params }: { params: { id: string } }) {
 
   return (
     <div className={`${theme.background}`}>
-      <div className=" fixed flex h-full w-full max-w-md flex-col">
-        <div className="flex h-full basis-3/12 flex-col">
-          <div className="flex h-full w-full basis-2/5 flex-row">
-          <div
-            className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
-            onClick={() => router.back()}
-          >
-            <Back color={theme.backIcon} />
+      <BackButtonHeader
+        title="스트링캣 공유하기"
+        backClickHandler={() => router.back()}
+      />
+      <div className="fixed flex h-full w-full max-w-md flex-col">
+        <div className="reltaive flex h-full w-full flex-col px-[24px]">
+          <div className="mt-24 flex w-full">
+            <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
           </div>
-          <div className=" basis-4/6">
-            <div
-              className={`text-center text-[18px] ${theme.titleText} mt-[16px]`}
-            >
-              스트링캣 공유하기
+          <div className="mt-[138px] flex h-full w-full flex-col">
+            <div className="flex h-full w-full basis-1/4 flex-row">
+              <SummaryBoard
+                contentCount={contentCount}
+                contentTextCount={contentTextCount}
+                summaryTextColor={theme.summaryText}
+              />
             </div>
           </div>
-          <div className=" basis-1/6" />
         </div>
-          <div className="mx-[24px] mt-[40px] basis-3/5">
-        <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
-          </div>
       </div>
-      <div className="flex h-full w-full basis-7/12 flex-col ">
-        <div className="basis-1/4" />
-        <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-          <SummaryBoard
-            contentCount={contentCount}
-            contentTextCount={contentTextCount}
-            summaryTextColor={theme.summaryText}
+      <div className="flex h-full w-full">
+        <div className="basis-1/2" />
+        <div className="basis-1/2 pr-[44px] pt-[186px]">
+          <LongCat
+            bodyColor={theme.catTheme.mainCat}
+            eyeColor={theme.catTheme.mainCatEye}
           />
         </div>
-        <div className="basis-1/2" />
       </div>
-        <div className="basis-2/12 " />
       <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
         <BottomButton
           height="h-[42px]"
@@ -80,16 +75,6 @@ export default function Summary({ params }: { params: { id: string } }) {
           disabled={false}
           color={`${theme.rightCTA}`}
         />
-        </div>
-      </div>
-      <div className="flex h-full w-full flex-row">
-        <div className="basis-1/2" />
-        <div className="basis-1/2 pr-[24px] pt-[186px]">
-          <LongCat
-            bodyColor={theme.catTheme.mainCat}
-            eyeColor={theme.catTheme.mainCatEye}
-          />
-        </div>
       </div>
     </div>
   );

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -65,7 +65,7 @@ export default function Summary({ params }: { params: { id: string } }) {
         <div className="flex h-full w-full basis-7/12 flex-col ">
           <div className="basis-1/4" />
           <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-            <div className={`${Theme.highlightText} w-full text-[26px] `}>
+            <div className={`${Theme.summaryText} w-full text-[26px] `}>
               총 {ContentCount}번의 <br /> 마음으로 <br /> 내 스트링캣이
               <br /> 총 {formatNumberWithCommas(ContentTextCount)}자
               <br />

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -30,7 +30,7 @@ export default function Summary({ params }: { params: { id: string } }) {
       })
       .catch((err) => {
         if (err.response?.status === 406) {
-          alert('올바르지 않은 입력입니다. 다시 작성해주세요.');
+          router.push('/not-found');
         }
       });
   }, []);

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -12,10 +12,10 @@ import { handleShare } from '@/utils/handleShare';
 
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
-  const [Theme, setTheme] = useRecoilState(themeState);
-  const [Title, setTitle] = useState('');
-  const [ContentCount, setContentCount] = useState(0);
-  const [ContentTextCount, setContentTextCount] = useState(0);
+  const [theme, setTheme] = useRecoilState(themeState);
+  const [title, setTitle] = useState('');
+  const [contentCount, setContentCount] = useState(0);
+  const [contentTextCount, setContentTextCount] = useState(0);
 
   useEffect(() => {
     axiosInstance
@@ -24,8 +24,8 @@ export default function Summary({ params }: { params: { id: string } }) {
         setTitle(res.data.title);
         setContentCount(res.data.contentCount);
         setContentTextCount(res.data.contentTextCount);
-        const themename: 'strcat' | 'cyan' | 'green' | 'calm' = res.data.theme;
-        setTheme(themeObj[themename]);
+        const themeName: 'strcat' | 'cyan' | 'green' | 'calm' = res.data.theme;
+        setTheme(themeObj[themeName]);
       })
       .catch((err) => {
         if (err.response?.status === 406) {
@@ -39,7 +39,7 @@ export default function Summary({ params }: { params: { id: string } }) {
   }
 
   return (
-    <div className={`${Theme.background}`}>
+    <div className={`${theme.background}`}>
       <div className=" fixed flex h-full w-full max-w-md flex-col">
         <div className="flex h-full basis-3/12 flex-col">
           <div className="flex h-full w-full basis-2/5 flex-row">
@@ -47,11 +47,11 @@ export default function Summary({ params }: { params: { id: string } }) {
               className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
               onClick={() => router.back()}
             >
-              <Back color={Theme.backIcon} />
+              <Back color={theme.backIcon} />
             </div>
             <div className=" basis-4/6">
               <div
-                className={`text-center text-[18px] ${Theme.titleText} mt-[16px]`}
+                className={`text-center text-[18px] ${theme.titleText} mt-[16px]`}
               >
                 스트링캣 공유하기
               </div>
@@ -59,17 +59,18 @@ export default function Summary({ params }: { params: { id: string } }) {
             <div className=" basis-1/6" />
           </div>
           <div className="mx-[24px] mt-[40px] basis-3/5">
-            <div className={`text-[22px] ${Theme.titleText}`}>{Title}</div>
+            <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
           </div>
         </div>
         <div className="flex h-full w-full basis-7/12 flex-col ">
           <div className="basis-1/4" />
           <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-            <div className={`${Theme.summaryText} w-full text-[26px] `}>
-              총 {ContentCount}번의 <br /> 마음으로 <br /> 내 스트링캣이
-              <br /> 총 {formatNumberWithCommas(ContentTextCount)}자
-              <br />
-              이어졌어요!
+            <div className={`${theme.summaryText} w-full text-[26px] `}>
+              총 {contentCount}번의
+              <br /> 마음으로
+              <br /> 내 스트링캣이
+              <br /> 총 {formatNumberWithCommas(contentTextCount)}자
+              <br /> 이어졌어요!
             </div>
           </div>
           <div className="basis-1/4" />
@@ -80,10 +81,10 @@ export default function Summary({ params }: { params: { id: string } }) {
           <BottomButton
             height="h-[42px]"
             name="공유하기"
-            width="w-[312px]"
+            width="w-full"
             onClickHandler={() => handleShare(`/personal/${params.id}`)}
             disabled={false}
-            color={`${Theme.rightCTA}`}
+            color={`${theme.rightCTA}`}
           />
         </div>
       </div>
@@ -91,8 +92,8 @@ export default function Summary({ params }: { params: { id: string } }) {
         <div className="basis-1/2" />
         <div className="basis-1/2 pr-[24px] pt-[186px]">
           <LongCat
-            bodyColor={Theme.catTheme.mainCat}
-            eyeColor={Theme.catTheme.mainCatEye}
+            bodyColor={theme.catTheme.mainCat}
+            eyeColor={theme.catTheme.mainCatEye}
           />
         </div>
       </div>

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -4,11 +4,11 @@ import { themeObj, themeState } from '@/recoil/theme';
 import { useRecoilState } from 'recoil';
 import { axiosInstance } from '@/utils/axios';
 import { useEffect, useState } from 'react';
-import BottomButton from '@/component/BottomButton';
 import { useRouter } from 'next/navigation';
+import { handleShare } from '@/utils/handleShare';
 import Back from '@/component/Icon/Back';
 import LongCat from '@/component/Icon/LongCat';
-import { handleShare } from '@/utils/handleShare';
+import BottomButton from '@/component/BottomButton';
 import SummaryBoard from '@/component/SummaryBoard';
 
 export default function Summary({ params }: { params: { id: string } }) {
@@ -40,46 +40,46 @@ export default function Summary({ params }: { params: { id: string } }) {
       <div className=" fixed flex h-full w-full max-w-md flex-col">
         <div className="flex h-full basis-3/12 flex-col">
           <div className="flex h-full w-full basis-2/5 flex-row">
+          <div
+            className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
+            onClick={() => router.back()}
+          >
+            <Back color={theme.backIcon} />
+          </div>
+          <div className=" basis-4/6">
             <div
-              className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
-              onClick={() => router.back()}
+              className={`text-center text-[18px] ${theme.titleText} mt-[16px]`}
             >
-              <Back color={theme.backIcon} />
+              스트링캣 공유하기
             </div>
-            <div className=" basis-4/6">
-              <div
-                className={`text-center text-[18px] ${theme.titleText} mt-[16px]`}
-              >
-                스트링캣 공유하기
-              </div>
-            </div>
-            <div className=" basis-1/6" />
           </div>
+          <div className=" basis-1/6" />
+        </div>
           <div className="mx-[24px] mt-[40px] basis-3/5">
-            <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
+        <div className={`text-[22px] ${theme.titleText}`}>{title}</div>
           </div>
-        </div>
-        <div className="flex h-full w-full basis-7/12 flex-col ">
-          <div className="basis-1/4" />
-          <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
-            <SummaryBoard
-              contentCount={contentCount}
-              contentTextCount={contentTextCount}
-              summaryTextColor={theme.summaryText}
-            />
-          </div>
-          <div className="basis-1/2" />
-        </div>
-        <div className="basis-2/12 " />
-        <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
-          <BottomButton
-            height="h-[42px]"
-            name="공유하기"
-            width="w-full"
-            onClickHandler={() => handleShare(`/personal/${params.id}`)}
-            disabled={false}
-            color={`${theme.rightCTA}`}
+      </div>
+      <div className="flex h-full w-full basis-7/12 flex-col ">
+        <div className="basis-1/4" />
+        <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
+          <SummaryBoard
+            contentCount={contentCount}
+            contentTextCount={contentTextCount}
+            summaryTextColor={theme.summaryText}
           />
+        </div>
+        <div className="basis-1/2" />
+      </div>
+        <div className="basis-2/12 " />
+      <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
+        <BottomButton
+          height="h-[42px]"
+          name="공유하기"
+          width="w-full"
+          onClickHandler={() => handleShare(`/personal/${params.id}`)}
+          disabled={false}
+          color={`${theme.rightCTA}`}
+        />
         </div>
       </div>
       <div className="flex h-full w-full flex-row">

--- a/src/app/personal/[id]/summary/page.tsx
+++ b/src/app/personal/[id]/summary/page.tsx
@@ -13,24 +13,22 @@ import { handleShare } from '@/utils/handleShare';
 export default function Summary({ params }: { params: { id: string } }) {
   const router = useRouter();
   const [Theme, setTheme] = useRecoilState(themeState);
-  const [Title, setTitle] = useState(
-    '테스트입니다테스트입니다테스트입니다테스트입니다테스트입니다',
-  );
-  const [ContentCount, setContentCount] = useState(13);
-  const [ContentTextCount, setContentTextCount] = useState(1305);
+  const [Title, setTitle] = useState('');
+  const [ContentCount, setContentCount] = useState(0);
+  const [ContentTextCount, setContentTextCount] = useState(0);
 
   useEffect(() => {
     axiosInstance
       .get(`/boards/${params.id}/summaries`)
-      .then((data) => {
-        setTitle(data.data.title);
-        setContentCount(data.data.contentCount);
-        setContentTextCount(data.data.contentTextCount);
-        const themename: 'strcat' | 'cyan' | 'green' | 'calm' = data.data.theme;
+      .then((res) => {
+        setTitle(res.data.title);
+        setContentCount(res.data.contentCount);
+        setContentTextCount(res.data.contentTextCount);
+        const themename: 'strcat' | 'cyan' | 'green' | 'calm' = res.data.theme;
         setTheme(themeObj[themename]);
       })
       .catch((err) => {
-        if (err.response.status === 406) {
+        if (err.response?.status === 406) {
           alert('올바르지 않은 입력입니다. 다시 작성해주세요.');
         }
       });
@@ -39,71 +37,58 @@ export default function Summary({ params }: { params: { id: string } }) {
   function formatNumberWithCommas(inputText: number) {
     return inputText.toLocaleString();
   }
+
   return (
     <div className={`${Theme.background}`}>
       <div className=" fixed flex h-full w-full max-w-md flex-col">
-        <div className=" basis-3/12">
-          <div className="flex h-full w-full flex-col">
-            <div className=" basis-2/5">
-              <div className=" flex h-full w-full flex-row">
-                <div
-                  className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
-                  onClick={() => router.back()}
-                >
-                  <Back color={Theme.backIcon} />
-                </div>
-                <div className=" basis-4/6">
-                  <div
-                    className={`text-center text-[18px] ${Theme.defaultText} mt-[16px]`}
-                  >
-                    스트링캣 공유하기
-                  </div>
-                </div>
-                <div className=" basis-1/6"></div>
+        <div className="flex h-full basis-3/12 flex-col">
+          <div className="flex h-full w-full basis-2/5 flex-row">
+            <div
+              className=" basis-1/6 items-center justify-center pl-[24px] pt-[16px]"
+              onClick={() => router.back()}
+            >
+              <Back color={Theme.backIcon} />
+            </div>
+            <div className=" basis-4/6">
+              <div
+                className={`text-center text-[18px] ${Theme.titleText} mt-[16px]`}
+              >
+                스트링캣 공유하기
               </div>
             </div>
-            <div className="mx-[25px]  mt-[7px] basis-3/5">
-              <div className={`text-[22px] ${Theme.defaultText}`}>{Title}</div>
-            </div>
+            <div className=" basis-1/6" />
+          </div>
+          <div className="mx-[24px] mt-[40px] basis-3/5">
+            <div className={`text-[22px] ${Theme.titleText}`}>{Title}</div>
           </div>
         </div>
-        <div className=" basis-7/12 ">
-          <div className=" flex h-full w-full flex-col ">
-            <div className=" basis-1/4"></div>
-            <div className=" basis-1/4">
-              <div className="flex h-full w-full flex-row">
-                <div className="basis-2/3">
-                  <div
-                    className={`${Theme.defaultText} mx-[24px] text-[26px] `}
-                  >
-                    총 {ContentCount}번의 <br /> 마음으로 <br /> 내 스트링캣이
-                    <br /> 총 {formatNumberWithCommas(ContentTextCount)}자
-                    <br />
-                    이어졌어요!
-                  </div>
-                </div>
-                <div className="basis-1/3"></div>
-              </div>
+        <div className="flex h-full w-full basis-7/12 flex-col ">
+          <div className="basis-1/4" />
+          <div className="flex h-full w-full basis-1/4 flex-row px-[24px]">
+            <div className={`${Theme.highlightText} w-full text-[26px] `}>
+              총 {ContentCount}번의 <br /> 마음으로 <br /> 내 스트링캣이
+              <br /> 총 {formatNumberWithCommas(ContentTextCount)}자
+              <br />
+              이어졌어요!
             </div>
-            <div className=" basis-1/4 "></div>
-            <div className=" basis-1/4"></div>
           </div>
+          <div className="basis-1/4" />
+          <div className="basis-1/4" />
         </div>
-        <div className=" mx-[25px] basis-2/12">
-          <div className="flex h-full w-full flex-row items-center justify-center">
-            <BottomButton
-              height="h-[42px]"
-              name="공유하기"
-              width="w-[312px]"
-              onClickHandler={() => handleShare(`/personal/${params.id}`)}
-              disabled={false}
-              color={`${Theme.rightCTA}`}
-            />
-          </div>
+        <div className="basis-2/12 " />
+        <div className="fixed bottom-[24px] flex w-full max-w-md items-center justify-center px-[24px]">
+          <BottomButton
+            height="h-[42px]"
+            name="공유하기"
+            width="w-[312px]"
+            onClickHandler={() => handleShare(`/personal/${params.id}`)}
+            disabled={false}
+            color={`${Theme.rightCTA}`}
+          />
         </div>
       </div>
       <div className="flex h-full w-full flex-row">
-        <div className="basis-1/2"></div>
+        <div className="basis-1/2" />
         <div className="basis-1/2 pr-[24px] pt-[186px]">
           <LongCat
             bodyColor={Theme.catTheme.mainCat}

--- a/src/component/HeaderLayout/BackButtonHeader.tsx
+++ b/src/component/HeaderLayout/BackButtonHeader.tsx
@@ -1,0 +1,29 @@
+import { themeState } from '@/recoil/theme';
+import { useRecoilState } from 'recoil';
+import Back from '../Icon/Back';
+
+interface Props {
+  title: string;
+  backClickHandler: () => void;
+}
+export default function BackButtonHeader({ title, backClickHandler }: Props) {
+  const [theme] = useRecoilState(themeState);
+
+  return (
+    <div className="fixed z-10 flex w-full max-w-md flex-col">
+      <div className="flex h-[56px] w-full ">
+        <div
+          className="flex basis-1/6 items-center pl-[24px]"
+          onClick={backClickHandler}
+        >
+          <Back color={theme.backIcon} />
+        </div>
+        <div
+          className={`${theme.titleText} flex basis-4/6 items-center justify-center text-center text-[18px]`}
+        >
+          {title}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/component/SummaryBoard.tsx
+++ b/src/component/SummaryBoard.tsx
@@ -19,7 +19,7 @@ export default function SummaryBoard({
     <div className={`${summaryTextColor} w-full text-[26px] `}>
       총 {contentCount}번의
       <br /> 마음으로
-      <br /> {boardCount ? `${boardCount}` : '내'} 스트링캣이
+      <br /> {boardCount ? `${boardCount}개의` : '내'} 스트링캣이
       <br /> 총 {formatNumberWithCommas(contentTextCount)}자
       <br /> 이어졌어요!
     </div>

--- a/src/component/SummaryBoard.tsx
+++ b/src/component/SummaryBoard.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  contentCount: number;
+  contentTextCount: number;
+  boardCount?: number;
+  summaryTextColor: string;
+}
+
+export default function SummaryBoard({
+  contentCount,
+  contentTextCount,
+  boardCount,
+  summaryTextColor,
+}: Props) {
+  function formatNumberWithCommas(inputText: number) {
+    return inputText.toLocaleString();
+  }
+
+  return (
+    <div className={`${summaryTextColor} w-full text-[26px] `}>
+      총 {contentCount}번의
+      <br /> 마음으로
+      <br /> {boardCount ? `${boardCount}` : '내'} 스트링캣이
+      <br /> 총 {formatNumberWithCommas(contentTextCount)}자
+      <br /> 이어졌어요!
+    </div>
+  );
+}

--- a/src/recoil/theme.ts
+++ b/src/recoil/theme.ts
@@ -24,6 +24,7 @@ export interface themeState {
   explainLeftCTA: string;
   titleText: string;
   placeholder: string;
+  summaryText: string;
 }
 
 export const strcat: themeState = {
@@ -43,6 +44,7 @@ export const strcat: themeState = {
   explainRightCTA: 'text-strcat-default-cyan',
   titleText: 'text-strcat-default-white',
   placeholder: 'placeholder:text-strcat-default-white',
+  summaryText: 'text-strcat-default-white',
 };
 
 export const calm: themeState = {
@@ -62,6 +64,7 @@ export const calm: themeState = {
   explainRightCTA: 'text-strcat-calm-text-cyan',
   titleText: 'text-strcat-calm-black',
   placeholder: 'placeholder:text-strcat-default-black',
+  summaryText: 'text-strcat-calm-black',
 };
 
 export const green: themeState = {
@@ -81,6 +84,7 @@ export const green: themeState = {
   explainRightCTA: 'strcat-cyan-black',
   titleText: 'text-strcat-green-black',
   placeholder: 'placeholder:text-strcat-default-yellow',
+  summaryText: 'text-strcat-green-black',
 };
 
 export const cyan: themeState = {
@@ -100,6 +104,7 @@ export const cyan: themeState = {
   explainRightCTA: 'strcat-cyan-black',
   titleText: 'text-strcat-cyan-white',
   placeholder: 'placeholder:text-strcat-default-white',
+  summaryText: 'text-strcat-cyan-black',
 };
 
 export const themeObj = {


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Pull-Request 생성 전 체크리스트(꼭 한번 읽어주세요!!)
  1. 이슈 이름은 다른 사람도 이해할 수 있나요?
  2. 리뷰가 필요한 사람(Reviewers)을 추가했나요?
  3. 이슈 책임자(Assignees)를 추가했나요?
  4. 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
    - [Feat]
    - [Docs]
    - [Chore]
    - [Refactor]
    - [Fix]
  5. Labels에는 해당 이슈의 성향을 잘 나타내나요?
  6. npm run build 명령을 모든 커밋 이후에 실행했나요?
 -->
# Describe your changes
- summary페이지를 피그마에 맞춰 테마 디자인을 변경했습니다. 
- 불필요한 div를 삭제했습니다.
- 변수 네이밍을 camelCase로 변경했습니다.
- summary 에서 board에 관해 띄워주는 부분이 공통적으로 personal, group페이지에서 사용되는 것을 확인하고, 
  컴포넌트로 분리했습니다. (Component/SummaryBoard.tsx)
- Back Button Header를 컴포넌트로 분리했습니다. (Component/HeaderLayout/BackButtonHeader.tsx)
   - 우선 summary에서는 문제 없이 돌아가는데, 다른 페이지에서도 동일하게 가져다 쓸수 있는지는 확인하지 못했습니다. 
   - create페이지들,  export페이지들에 반영시 BackButtonHeader를 다시 조정하는 작업이 필요할 듯합니다.
- api에서 406에러 발생시 not-found페이지로 라우팅했습니다.

> P.S) summary가 공유버튼이 눌렸을때 가는 페이진데 공유의 느낌이 url에 없어서, 혹시 share로 변경하는 건 어떨지 제안해봅니다!
          - personal/[id]/share
          - group/[id]/share

## Screen Capture
### personal summary

<img width="348" alt="Screenshot 2023-12-01 at 12 48 48 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/2bcdc43e-aa97-46e9-bcb0-2065ed8b5683">
<img width="344" alt="Screenshot 2023-12-01 at 12 48 21 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/269e7942-ffe3-4a61-b56c-98aa30e59d34">
<img width="348" alt="Screenshot 2023-12-01 at 12 45 39 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/b0f05c9d-30d7-44ad-923e-c9a6b4e79e91">
<img width="342" alt="Screenshot 2023-12-01 at 12 45 27 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/4f90485b-ccb2-43e9-aeb0-bb2a7852284a">

### group summary
<img width="344" alt="Screenshot 2023-12-01 at 12 49 09 PM" src="https://github.com/RollingPaper42/Front-End/assets/46983641/19f123ae-3d30-4c78-9bab-bf1346209fb7">


# Issue number and link
- #172 
