### PR TITLE
[Feat] inapp browser 비활성화 

### DIFF
--- a/src/app/InApp.tsx
+++ b/src/app/InApp.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+
+export default function InApp() {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const inappdeny_exec = (callback: () => void) => {
+        if (document.readyState !== 'loading') {
+          callback();
+        } else {
+          document.addEventListener('DOMContentLoaded', callback);
+        }
+      };
+
+      inappdeny_exec(() => {
+        async function inappbrowserout() {
+          navigator.clipboard.writeText(window.location.href);
+          alert(
+            'URL주소가 복사되었습니다.\n\nSafari가 열리면 주소창을 길게 터치한 뒤, "붙여놓기 및 이동"를 누르면 정상적으로 이용하실 수 있습니다.',
+          );
+          location.href = 'x-web-search://?';
+        }
+
+        const useragt = navigator.userAgent.toLowerCase();
+        const target_url = location.href;
+
+        if (useragt.match(/kakaotalk/i)) {
+          //카카오톡 외부브라우저로 호출
+          location.href =
+            'kakaotalk://web/openExternal?url=' +
+            encodeURIComponent(target_url);
+        } else if (useragt.match(/line/i)) {
+          //라인 외부브라우저로 호출
+          if (target_url.indexOf('?') !== -1) {
+            location.href = target_url + '&openExternalBrowser=1';
+          } else {
+            location.href = target_url + '?openExternalBrowser=1';
+          }
+        } else if (
+          useragt.match(
+            /inapp|naver|snapchat|wirtschaftswoche|thunderbird|instagram|everytimeapp|whatsApp|electron|wadiz|aliapp|zumapp|iphone(.*)whale|android(.*)whale|kakaostory|band|twitter|DaumApps|DaumDevice\/mobile|FB_IAB|FB4A|FBAN|FBIOS|FBSS|trill|SamsungBrowser\/[^1]/i,
+          )
+        ) {
+          //그외 다른 인앱들
+          if (useragt.match(/iphone|ipad|ipod/i)) {
+            //아이폰은 강제로 사파리를 실행할 수 없음
+            //모바일대응뷰포트강제설정
+            var mobile = document.createElement('meta');
+            mobile.name = 'viewport';
+            mobile.content =
+              'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, minimal-ui';
+            document.getElementsByTagName('head')[0].appendChild(mobile);
+            // //노토산스폰트강제설정
+            // var fonts = document.createElement('link');
+            // fonts.href =
+            //   'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap';
+            // document.getElementsByTagName('head')[0].appendChild(fonts);
+            document.body.innerHTML =
+              "<style>body{margin:0;padding:0;font-family: 'Noto Sans KR', sans-serif;overflow: hidden;height: 100%;}</style>\
+              <h2 style='padding-top:50px; text-align:center;font-family: 'Noto Sans KR', sans-serif;'>인앱브라우저 호환문제로 인해<br />\
+              Safari로 접속해야합니다.</h2>\
+              <article style='text-align:center; font-size:17px; word-break:keep-all;color:#999;'>아래 버튼을 눌러 Safari를 실행해주세요<br />\
+              Safari가 열리면, 주소창을 길게 터치한 뒤,<br />'붙여놓기 및 이동'을 누르면<br />정상적으로 이용할 수 있습니다.<br />\
+              <br /><button onclick='inappbrowserout();' \
+              style='min-width:180px;margin-top:10px;height:54px;font-weight: 700;background-color:#31408E;color:#fff;border-radius: 4px;font-size:17px;border:0;'>\
+              Safari로 열기</button></article><img style='width:70%;margin:50px 15% 0 15%' src='https://tistory3.daumcdn.net/tistory/1893869/skin/images/inappbrowserout.jpeg' />";
+          } else {
+            //안드로이드는 Chrome이 설치되어있음으로 강제로 스킴실행한다.
+            location.href =
+              'intent://' +
+              target_url.replace(/https?:\/\//i, '') +
+              '#Intent;scheme=http;package=com.android.chrome;end';
+          }
+        }
+      });
+    } else {
+      return;
+    }
+  }, []);
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { RecoilRoot } from 'recoil';
 import './globals.css';
 import Modal from '@/component/Modal';
 import AxiosInterceptor from '@/component/AxiosInterceptor';
+import InApp from './InApp';
 
 export default function RootLayout({
   children,
@@ -15,6 +16,7 @@ export default function RootLayout({
       <body className="h-full overscroll-none">
         <div className="m-auto h-full max-w-md font-sans">
           <RecoilRoot>
+            <InApp />
             <AxiosInterceptor />
             <Modal />
             {children}


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Pull-Request 생성 전 체크리스트(꼭 한번 읽어주세요!!)
  1. 이슈 이름은 다른 사람도 이해할 수 있나요?
  2. 리뷰가 필요한 사람(Reviewers)을 추가했나요?
  3. 이슈 책임자(Assignees)를 추가했나요?
  4. 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
    - [Feat]
    - [Docs]
    - [Chore]
    - [Refactor]
    - [Fix]
  5. Labels에는 해당 이슈의 성향을 잘 나타내나요?
  6. npm run build 명령을 모든 커밋 이후에 실행했나요?
 -->
# Describe your changes
- 카카오톡, 라인 등의 인앱 브라우저에서 디자인 호환이 되지 않아서 인앱 브라우저 강제 비활성화를 시도했습니다. 
- 네이버, 스냅챗, 인스타그램, 웨일, 밴드, 트위터, 삼성 브라우저 등에서도 해당 코드를 실행시켜 아이폰의 경우 사파리로, 안드로이드폰의 경우 크롬으로 이동하도록 했습니다. 
- 로컬테스트에서는 잘 작동하는 것을 확인했는데, 안드로이드 폰에 대해서는 확인하지 못했으므로, 배포 이후 여러가지 테스트가 필요합니다. 
- layout에서 불러쓰는 컴포넌트라서 위치를 app/InApp.tsx로 두었는데 component/InApp.tsx로 변경해도 괜찮을 것 같습니다 

# Issue number and link
- #192
