### PR TITLE
[refactor] 데이터 코드 분리, 뷰 코드 리팩토링 #377

### DIFF
--- a/src/component/Personal/FirstContent.tsx
+++ b/src/component/Personal/FirstContent.tsx
@@ -1,0 +1,30 @@
+import NoneContent from './NoneContent';
+import Summary from './Summary';
+
+interface Props {
+  boardLength: number;
+  windowHeight: number;
+  id: string;
+  handleClickNonContent: () => void;
+}
+
+export default function FirstContent({
+  boardLength,
+  windowHeight,
+  id,
+  handleClickNonContent,
+}: Props) {
+  return (
+    <>
+      {boardLength !== 0 && (
+        <div className="absolute top-[100px]">
+          <Summary id={id} />
+        </div>
+      )}
+      <div style={{ paddingTop: `${windowHeight * 0.4}px` }} />
+      {boardLength === 0 && (
+        <NoneContent handleClickWrite={handleClickNonContent} />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Pull-Request 생성 전 체크리스트(꼭 한번 읽어주세요!!)
  1. 이슈 이름은 다른 사람도 이해할 수 있나요?
  2. 리뷰가 필요한 사람(Reviewers)을 추가했나요?
  3. 이슈 책임자(Assignees)를 추가했나요?
  4. 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
    - [Feat]
    - [Docs]
    - [Chore]
    - [Refactor]
    - [Fix]
  5. Labels에는 해당 이슈의 성향을 잘 나타내나요?
  6. npm run build 명령을 모든 커밋 이후에 실행했나요?
 -->
# Describe your changes
- personal 페이지 데이터 받아오는 로직을 데이터만 받아서 리턴하게 리팩토링
  - 데이터를 받아오는 함수를 만들어 분리 하였고 같은 파일에서 useData라는 이름으로 호출 하는 방식으로 구현
  - 고려사항
     - 액션, 뷰, 데이터 코드 분리
- 콘텐츠 길이가 0일 때, 0이 아닐 때 다른 화면을 띄워주는 로직을 컴포넌트로 묶어두었습니다
## Screen Capture

# Issue number and link
- #377 
