### PR TITLE
[Feat] board history 기능 추가 #390

### DIFF
--- a/src/app/login/check/page.tsx
+++ b/src/app/login/check/page.tsx
@@ -4,10 +4,22 @@ import { useEffect } from 'react';
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { History } from '@/types/history';
+import { axiosPostUserHistory } from '@/utils/apiInterface';
+
 export default function Check() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
+
+  useEffect(() => {
+    const history = localStorage.getItem('history');
+    if (history) {
+      const historyArray: History[] = JSON.parse(history);
+      axiosPostUserHistory({ history: historyArray });
+      localStorage.removeItem('history');
+    }
+  }, []);
 
   useEffect(() => {
     localStorage.setItem('strcat_token', token ?? '');

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -35,16 +35,14 @@ export default function Personal({ params }: { params: { id: string } }) {
   const { isHidden, setIsHidden } = useScroll();
   const [windowHeight, setWindowHeight] = useState(0);
   const [toastMessage, setToastMessage] = useState('');
+ 
+  const addHistory = ()=>{
+    const timestamp = () => {
+      var now = new Date();
+      now.setHours(now.getHours() + 9);
+      return now.toISOString().replace('T', ' ').substring(0, 19);
+    };
 
-  const timestamp = () => {
-    var now = new Date();
-    now.setHours(now.getHours() + 9);
-    return now.toISOString().replace('T', ' ').substring(0, 19);
-  };
-
-  useEffect(() => {
-    const token = localStorage.getItem('strcat_token');
-    if (token) return;
     const history = localStorage.getItem('history');
     let historyArray: History[] = history ? JSON.parse(history) : [];
     if (history) {
@@ -64,7 +62,13 @@ export default function Personal({ params }: { params: { id: string } }) {
       title: title,
     });
     localStorage.setItem('history', JSON.stringify(historyArray));
-  }, [params.id, title]);
+  }
+
+  useEffect(() => {
+    const token = localStorage.getItem('strcat_token');
+    if (token) return;
+    addHistory();
+  }, []);
 
   useEffect(() => {
     if (window) setWindowHeight(window.innerHeight);

--- a/src/app/personal/[id]/page.tsx
+++ b/src/app/personal/[id]/page.tsx
@@ -20,6 +20,7 @@ import { useScroll } from '@/hooks/useScroll';
 import { titleState } from '@/recoil/title';
 import { logging } from '@/services/mixpanel';
 import { board } from '@/types/boards';
+import { History } from '@/types/history';
 import { personalPage } from '@/types/mixpanel';
 import { noneTheme, themeState } from '@/types/theme';
 import { chris, lilac, mas, night, peach, sul } from '@/types/theme';
@@ -34,6 +35,36 @@ export default function Personal({ params }: { params: { id: string } }) {
   const { isHidden, setIsHidden } = useScroll();
   const [windowHeight, setWindowHeight] = useState(0);
   const [toastMessage, setToastMessage] = useState('');
+
+  const timestamp = () => {
+    var now = new Date();
+    now.setHours(now.getHours() + 9);
+    return now.toISOString().replace('T', ' ').substring(0, 19);
+  };
+
+  useEffect(() => {
+    const token = localStorage.getItem('strcat_token');
+    if (token) return;
+    const history = localStorage.getItem('history');
+    let historyArray: History[] = history ? JSON.parse(history) : [];
+    if (history) {
+      const existingIndex = historyArray.findIndex(
+        (history) => history.encryptedBoardId === params.id,
+      );
+      if (existingIndex !== -1) {
+        historyArray.splice(existingIndex, 1);
+      }
+      while (historyArray.length >= 10) {
+        historyArray.shift();
+      }
+    }
+    historyArray.push({
+      visitTime: timestamp(),
+      encryptedBoardId: params.id,
+      title: title,
+    });
+    localStorage.setItem('history', JSON.stringify(historyArray));
+  }, [params.id, title]);
 
   useEffect(() => {
     if (window) setWindowHeight(window.innerHeight);

--- a/src/component/Common/HeaderLayout/Drawer.tsx
+++ b/src/component/Common/HeaderLayout/Drawer.tsx
@@ -17,7 +17,9 @@ import { useLogin } from '@/hooks/useLogin';
 import { drawerState } from '@/recoil/drawer';
 import { titleFontState } from '@/recoil/font/title';
 import { drawerBoard } from '@/types/drawerBoard';
+import { History } from '@/types/history';
 import { axiosGetUserBoard } from '@/utils/apiInterface';
+import { axiosGetUserHistory } from '@/utils/apiInterface';
 import { handleBackground } from '@/utils/handleBackground';
 import { defaultState } from '@/utils/theme/default';
 
@@ -26,6 +28,7 @@ export default function Drawer() {
   const [drawer, setDrawer] = useRecoilState(drawerState);
   const [drawerClosing, setDrawerClosing] = useState(false);
   const [personalList, setPersonalList] = useState<drawerBoard[]>([]);
+  const [historyList, setHistoryList] = useState<History[]>([]);
   const router = useRouter();
   const pathname = usePathname();
 
@@ -33,10 +36,13 @@ export default function Drawer() {
     try {
       const personal = await axiosGetUserBoard();
       setPersonalList(personal.data);
+      const history = await axiosGetUserHistory();
+      setHistoryList(history.data);
+      // history 뷰는 아직 구현 안함
     } catch (err) {
       const error = err as AxiosError;
     }
-  }, [setPersonalList]);
+  }, [setPersonalList, setHistoryList]);
 
   const drawerSlowClose = () => {
     setDrawerClosing(true);

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,5 @@
+export interface History {
+  visitTime: string;
+  encryptedBoardId: string;
+  title: string;
+}

--- a/src/utils/apiInterface.tsx
+++ b/src/utils/apiInterface.tsx
@@ -16,6 +16,10 @@ export const axiosGetLoginCheck = () => {
   return axiosInstance.get(`/login/check`);
 };
 
+export const axiosGetUserHistory = () => {
+  return axiosInstance.get('/users/history');
+};
+
 export const axiosPostBoard = (requestData: any) => {
   return axiosInstance.post('/boards', requestData);
 };
@@ -26,4 +30,8 @@ export const axiosPostBoardContent = (id: string, requestData: any) => {
 
 export const axiosPostBoardContentPicture = (id: string, requestData: any) => {
   return axiosInstance.post(`/boards/${id}/contents/pictures`, requestData);
+};
+
+export const axiosPostUserHistory = (requestData: any) => {
+  return axiosInstance.post('/users/history', requestData);
 };


### PR DESCRIPTION
<!-- (주석) 모두가 보는 게시물입니다. 다른 사람도 이해 할 수 있는 언어로 작성해주시길 바래요~ 바른 말 고운 말 쓰라 이 말이야!

# Pull-Request 생성 전 체크리스트(꼭 한번 읽어주세요!!)
  1. 이슈 이름은 다른 사람도 이해할 수 있나요?
  2. 리뷰가 필요한 사람(Reviewers)을 추가했나요?
  3. 이슈 책임자(Assignees)를 추가했나요?
  4. 제목 가장 좌측에 해당 pull-request의 성향을 잘 나타내는 키워드가 있나요? 아래는 예시입니다! 복사해서 사용하세요!
    - [Feat]
    - [Docs]
    - [Chore]
    - [Refactor]
    - [Fix]
  5. Labels에는 해당 이슈의 성향을 잘 나타내나요?
  6. npm run build 명령을 모든 커밋 이후에 실행했나요?
 -->
# Describe your changes
- 로그인상태가 아닐경우 중복없이 접속한 보드에 대한 history를 10개까지 쌓고, login을 하면 그 기록을 백엔드로 전송했습니다.
- drawer 호출시 personal board list 와 함께 history board list 를 받는 부분을 추가했으나, 아직 view가 없어서 보이지는 않습니다 ^&^

## Screen Capture
- 현재 drawer에서 보여주는 view 에 대한 디자인이 완료되지 않음

# Issue number and link
- #390
